### PR TITLE
Update Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm test:unit
+    - run: npm run test:unit
       env:
         CI: true


### PR DESCRIPTION
This PR removes node v12 from the CI pipeline, and updates the test command.

There are some dependencies which currently do not work on versions of node newer than 10.x. We can leave the matrix strategy in place, and as the dependencies get updated, we can revisit the CI pipeline to add newer versions of node back in.

Additionally, the test command was missing 'run', so the step would always fail.