### PR TITLE
Get realtime database saving on the edit and add user pages

### DIFF
--- a/cl8-web/src/components/admin/AddUser.vue
+++ b/cl8-web/src/components/admin/AddUser.vue
@@ -190,9 +190,7 @@ export default {
   },
   firebase: function() {
     return {
-      fbpeeps: {
-        source: fbase.database().ref('userlist')
-      }
+      items: fbase.database().ref('userlist')
     }
   },
   data() {
@@ -296,7 +294,7 @@ export default {
     }
   },
   created() {
-    this.$bindAsArray('items', this.$firebaseRefs.fbpeeps)
+    this.$rtdbBind('items', fbase.database().ref('userlist'))
   }
 }
 </script>

--- a/cl8-web/src/components/profile/ProfileEdit.vue
+++ b/cl8-web/src/components/profile/ProfileEdit.vue
@@ -170,13 +170,7 @@ export default {
   },
   firebase: function() {
     return {
-      fbpeeps: {
-        source: fbase.database().ref('userlist'),
-        readyCallback: function() {
-          debug('data retrieved from fbase')
-          this.setUserProfile()
-        }
-      }
+      items: fbase.database().ref('userlist')
     }
   },
   data() {
@@ -215,11 +209,6 @@ export default {
           }
         })
       }
-      if (this.unsyncedTags.length > 0) {
-        this.unsyncedTags.forEach(function(t) {
-          tagList.push(t)
-        })
-      }
       return tagList
     }
   },
@@ -233,7 +222,6 @@ export default {
         id: 'tempval' + tempVal
       }
       this.profile.fields.tags.push(tag)
-      this.unsyncedTags.push(tag)
     },
     onSubmit: function(item) {
       debug('updating profile', this.profile)
@@ -290,7 +278,20 @@ export default {
     }
   },
   created() {
-    this.$bindAsArray('items', this.$firebaseRefs.fbpeeps)
+    // we need a reference to our 'this' from insie the scope of the
+    // success and fail callbacks in the Promise
+    const that = this;
+
+    this.$rtdbBind('items', fbase.database().ref('userlist')).then(
+      function() {
+          debug('data retrieved from fbase')
+          console.log(that)
+          that.setUserProfile()
+      }).catch(
+        function(err) {
+          console.log(err);
+      })
+
     debug('checking for a user:')
     debug(this.$store.getters.profile)
     debug(fbase.auth().currentUser)

--- a/cl8-web/src/main.js
+++ b/cl8-web/src/main.js
@@ -6,7 +6,7 @@ import App from './App'
 import router from './routes'
 import store from './store'
 import VeeValidate from 'vee-validate'
-import { firestorePlugin } from 'vuefire'
+import { rtdbPlugin } from 'vuefire'
 import VueFuse from 'vue-fuse'
 import fbase from './fbase'
 import VueAnalytics from 'vue-analytics'
@@ -33,7 +33,7 @@ const dict = {
 
 Vue.use(VeeValidate, vvConfig)
 Vue.use(VueFuse)
-Vue.use(firestorePlugin)
+Vue.use(rtdbPlugin)
 
 Vue.use(VueAnalytics, {
   id: process.env.VUE_APP_GOOGLE_ANALYTICS_UA,

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -386,17 +386,17 @@ export default new Vuex.Store({
     updateProfile: function(context, payload) {
       debug('sending update to Firebase', payload)
 
-      // not super happy about this - surely there's a toJSON() method?
+      // doing this round trip returns a JSON object we
+      // can save back to the realtime database more easily,
+      // and strips out properties we wouldn't want to save into it
       let newProfile = JSON.parse(JSON.stringify(payload))
-      // check if this is a profile with no pushkey, and fetch it if so
-      const pushKey = newProfile['.key']
+      const pushKey = payload['.key'];
 
       if (!pushKey) {
         throw new Error(
           'this profile has no push key. this is needed for writing data'
         )
       }
-      delete newProfile['.key']
 
       return fbase
         .database()


### PR DESCRIPTION
This is PR adds the required code  for listing tags on the add user and edit profile screens in constellate.

Where most of the state is manipulated through the store with VueX, the lists of tags where generated by using the VueFire extension, and the single file components needed to be updated to support the editing and creation of tags, using the newer syntax.


You can see more below, on the VueFire docs.
https://vuefire.vuejs.org/vuefire/upgrading-from-v1.html#renamed-import-for-the-rtdb

