### PR TITLE
Add passwordless email

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -73,6 +73,7 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount",
     "rest_framework",
     "rest_framework.authtoken",
+    "drfpasswordless",
     "taggit",
     "corsheaders",
 ]
@@ -102,6 +103,11 @@ AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "users:redirect"
 # https://docs.djangoproject.com/en/dev/ref/settings/#login-url
 LOGIN_URL = "account_login"
+
+PASSWORDLESS_AUTH = {
+    'PASSWORDLESS_AUTH_TYPES': ['EMAIL'],
+    'PASSWORDLESS_EMAIL_NOREPLY_ADDRESS': 'noreply@greening.digital',
+}
 
 # PASSWORDS
 # ------------------------------------------------------------------------------

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -25,6 +25,7 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("auth-token/", obtain_auth_token),
+    path('', include('drfpasswordless.urls')),
 ]
 
 if settings.DEBUG:

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -18,3 +18,5 @@ django-redis==4.12.1  # https://github.com/jazzband/django-redis
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
 django-taggit==1.3.0 # https://github.com/jazzband/django-taggit
 django-taggit-serializer==0.1.7 # https://github.com/glemmaPaul/django-taggit-serializer
+django-cors-headers==3.4.0 # https://github.com/adamchainz/django-cors-headers
+drfpasswordless==1.5.4 # https://github.com/aaronn/django-rest-framework-passwordless


### PR DESCRIPTION
This introduces the passwordless auth as described at the link below:

https://github.com/aaronn/django-rest-framework-passwordless


Send a POST to the `auth/email` endpoint like so:

```
requests.post("http://localhost:8000/auth/email/", {"email": "user@domain.com"})
```

It'll trigger an email. You can see the email sent, if use mailhog locally/

This gives the token to use, for posting to the next endpoint. you'd typically this with a form-encoded payload like so:

```
res2 = requests.post("http://localhost:8000/auth/token/", {"email": "wave+local@chrisadams.me.uk", "token":"862471"})
```

The response will be a token, which can be used for auth:

```
{"token":"b51c4e2c94f92a56cdc24d8310047fd7c06327eb"}'
```