### PR TITLE
Skip saving the problematic values for PUTs and POSTs

### DIFF
--- a/backend/backend/users/api/serializers.py
+++ b/backend/backend/users/api/serializers.py
@@ -79,13 +79,27 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
 
-        for user_key in ['name', 'email']:
+        for user_key in ['name', 'email', 'admin']:
             if user_key in validated_data.keys():
                 value = validated_data.pop(user_key)
-                setattr(instance.user, user_key, value)
+
+                if user_key == 'admin':
+                    instance.is_staff = value
+                else:
+                    setattr(instance.user, user_key, value)
+
         instance.user.save()
 
         for attr, value in validated_data.items():
+
+            # some values we don't want to allow setting
+            # via the API
+            if attr in ['id', 'tags']:
+                continue
+
+            if not value:
+                continue
+
             setattr(instance, attr, value)
         instance.save()
 


### PR DESCRIPTION
This PR fixes some of the bugs from merging in the front and backend work

- [ ] fix the format for sending tags
- [x] set admin on the correct object 🤦‍♂️
- [x] make sure only the value we want to change are changeable via the API (as in no changing of `id`)