### PR TITLE
Rename blurb to bio

### DIFF
--- a/cl8-web/src/components/admin/AddUser.vue
+++ b/cl8-web/src/components/admin/AddUser.vue
@@ -146,7 +146,7 @@
                     </label>
                     <textarea
                       class="w-100 mt1 pa1 ba b--light-gray"
-                      v-model="profile.blurb"
+                      v-model="profile.bio"
                       placeholder="Add a short summary here - 2 paragraphs is plenty"
                       name
                       id
@@ -210,7 +210,7 @@ export default {
         twitter: '',
         facebook: '',
         linkedin: '',
-        blurb: '',
+        bio: '',
         visible: true,
         pitchable: false,
         tags: []

--- a/cl8-web/src/components/profile/ProfileDetail.vue
+++ b/cl8-web/src/components/profile/ProfileDetail.vue
@@ -86,8 +86,8 @@
           >{{ tag.name.toLowerCase().trim() }}</li>
         </ul>
 
-        <div v-if="this.profile.blurb" class="w-100 blurb lh-copy measure-wide">
-          <div v-html="blurbOutput"></div>
+        <div v-if="this.profile.bio" class="w-100 bio lh-copy measure-wide">
+          <div v-html="bioOutput"></div>
         </div>
       </div>
     </div>
@@ -145,10 +145,8 @@ export default {
         ? linkify(this.profile.linkedin, 'https://linkedin.com/in')
         : null
     },
-    blurbOutput() {
-      return this.profile.blurb
-        ? marked(sanitizeHTML(this.profile.blurb))
-        : null
+    bioOutput() {
+      return this.profile.bio ? marked(sanitizeHTML(this.profile.bio)) : null
     }
   },
   methods: {

--- a/cl8-web/src/components/profile/ProfileEdit.vue
+++ b/cl8-web/src/components/profile/ProfileEdit.vue
@@ -118,7 +118,7 @@
                     </label>
                     <textarea
                       class="w-100 mt1 pa1 ba b--light-gray"
-                      v-model="profile.blurb"
+                      v-model="profile.bio"
                       placeholder="Add a short summary here - 2 paragraphs is plenty"
                       name
                       id

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -277,7 +277,7 @@ const actions = {
    * - twitter
    * - facebook
    * - linkedin
-   * - blurb (summary)
+   * - bio (summary)
    * - visible (boolean)
    * - pitchable (boolean)
    */
@@ -299,7 +299,7 @@ const actions = {
         twitter: payload.twitter,
         facebook: payload.facebook,
         linkedin: payload.linkedin,
-        blurb: payload.blurb,
+        bio: payload.bio,
         visible: payload.visible,
         pitchable: payload.pitchable,
         tags: payload.tags


### PR DESCRIPTION
This is a simple PR renaming blurb to bio.

The new back end renamed the field to something more semantically correct, so the front end has been updated to match.