### PR TITLE
Server required fields for output on POST

### DIFF
--- a/backend/backend/users/api/views.py
+++ b/backend/backend/users/api/views.py
@@ -49,23 +49,17 @@ class ProfileViewSet(
         else:
             request_data = request.data
 
-        request_data_dict = {
-            key:val for key, val
-            in request_data.items()
-            if val
-        }
-
-        email = request_data_dict.pop("email")
-        full_name = request_data_dict.pop("name")
+        email = request_data.pop("email")
+        full_name = request_data.pop("name")
         username = slugify(full_name)
 
         # validate User with User serializer
         new_user = User.objects.create_user(username, email, name=full_name)
 
         # create our profile
-        request_data_dict["user_id"] = new_user.id
+        request_data["user_id"] = new_user.id
 
-        serialized_profile = ProfileSerializer(data=request_data_dict)
+        serialized_profile = ProfileSerializer(data=request_data)
         serialized_profile.is_valid(raise_exception=True)
         serialized_profile.create(serialized_profile.validated_data, user=new_user)
 
@@ -82,13 +76,6 @@ class ProfileViewSet(
             request_data = request.data.dict()
         else:
             request_data = request.data
-
-        request_data_dict = {
-            key:val for key, val
-            in request_data.items()
-            if val
-        }
-
 
         profile_id = resolve(request.path).kwargs['id']
         instance = Profile.objects.get(id=profile_id)

--- a/backend/backend/users/tests/test_drf_views.py
+++ b/backend/backend/users/tests/test_drf_views.py
@@ -92,6 +92,29 @@ class TestProfileViewSet:
         assert response.status_code == 201
 
     @pytest.mark.only
+        expected_fields = [
+            'id',
+
+            'name',
+            'email',
+
+            'phone',
+            'website',
+            'twitter',
+            'facebook',
+            'linkedin',
+
+            'tags',
+            'bio',
+            'admin',
+            'visible',
+            'photo'
+        ]
+
+        for field in expected_fields:
+            assert field in response.data.keys()
+
+
     def test_update_profile(self, profile: Profile, rf: RequestFactory):
         view = ProfileViewSet()
         request = rf.get(f"/api/profiles/{profile.id}/")


### PR DESCRIPTION
Wow, what a faff. 

After diving into the internals of how DRF represents objects, it ended up being simpler to just add the missing fields the moment before we return a data structure.

So that's what this change does in the create view.