### PR TITLE
Ca add missing photo url

### DIFF
--- a/backend/backend/users/api/serializers.py
+++ b/backend/backend/users/api/serializers.py
@@ -43,6 +43,9 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
     def add_photo_url(self, instance):
         """
         Add the photo url for the output representation of a profile object.
+        Largely replicates the logic visible at:
+        https://github.com/encode/django-rest-framework/blob/3.3.3/rest_framework/fields.py#L1378
+
         """
 
         url = instance.photo.url

--- a/backend/backend/users/api/serializers.py
+++ b/backend/backend/users/api/serializers.py
@@ -40,6 +40,25 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
     name = serializers.CharField(allow_blank=True, required=False)
     email = serializers.EmailField(allow_blank=True, required=False)
 
+    def add_photo_url(self, instance):
+        """
+        Add the photo url for the output representation of a profile object.
+        """
+
+        url = instance.photo.url
+        
+        request = self.context.get('request', None)
+        if request is not None:
+            return request.build_absolute_uri(url)
+
+        return url
+
+    def to_representation(self, instance):
+        res = super().to_representation(instance)
+        res['photo'] = self.add_photo_url(instance)
+        return res
+
+
     def create(self, validated_data, user=None):
 
         ModelClass = self.Meta.model
@@ -114,7 +133,6 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
 
             # need their own handler
             "tags",
-            "photo",
         ]
 
 

--- a/backend/backend/users/api/serializers.py
+++ b/backend/backend/users/api/serializers.py
@@ -47,6 +47,10 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
         https://github.com/encode/django-rest-framework/blob/3.3.3/rest_framework/fields.py#L1378
 
         """
+        try:
+            url = instance.photo.url
+        except ValueError:
+            return None
 
         url = instance.photo.url
         


### PR DESCRIPTION
This replaces the inclusion of photo as an editable field in the JSON API in favour of including the representation we send to clients, without needing it to be send in the PUT/POSTs to the main api/profile endpoint.