### PR TITLE
Update how tags are saved when send to the API

### DIFF
--- a/backend/backend/conftest.py
+++ b/backend/backend/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+import factory
+import random
 from backend.users.models import User, Profile
 from backend.users.tests.factories import UserFactory, ProfileFactory, FakePhotoProfileFactory
 
@@ -16,6 +18,13 @@ def user() -> User:
 @pytest.fixture
 def profile(user) -> Profile:
     return ProfileFactory(user=user)
+
+@pytest.fixture
+def profile_with_tags(user) -> Profile:
+    profile = ProfileFactory(user=user)
+    words = factory.Faker('words', nb=random.randint(0,6)).generate()
+    profile.tags.add(*words)
+    return profile
 
 @pytest.fixture
 def fake_photo_profile(user) -> Profile:

--- a/backend/backend/users/api/views.py
+++ b/backend/backend/users/api/views.py
@@ -56,16 +56,13 @@ class ProfileViewSet(
 
         partial = kwargs.pop("partial", False)
 
-        if isinstance(request.data, QueryDict):
-            request_data = request.data.dict()
-        else:
-            request_data = request.data
+        inbound_data = request.data.copy()
 
         profile_id = resolve(request.path).kwargs['id']
         instance = Profile.objects.get(id=profile_id)
 
         serialized_profile = self.serializer_class(
-            instance, data=request_data, partial=partial
+            instance, data=inbound_data, partial=partial
         )
         serialized_profile.is_valid(raise_exception=True)
         serialized_profile.update(instance, serialized_profile.validated_data)

--- a/backend/backend/users/tests/factories.py
+++ b/backend/backend/users/tests/factories.py
@@ -15,6 +15,8 @@ from factory.django import ImageField as ImageFieldFactory
 import requests
 from django.db.models.signals import post_save
 
+from taggit.models import Tag
+
 def generated_profile_photo():
     image_bytes = requests.get("https://www.thispersondoesnotexist.com/image").content
     return io.BytesIO(image_bytes)
@@ -65,6 +67,20 @@ def url_factory():
     return f"https://{domain_generator.generate()}"
 
 
+class TagFactory(DjangoModelFactory):
+
+    name = Faker('word')
+
+    class Meta:
+        model = Tag
+
+
+
+
+def list_of_tags():
+    website = factory.LazyFunction(url_factory)
+
+
 @factory.django.mute_signals(post_save)
 class ProfileFactory(DjangoModelFactory):
 
@@ -79,7 +95,7 @@ class ProfileFactory(DjangoModelFactory):
     linkedin = Faker("user_name")
     bio = Faker("paragraph")
 
-    #
+    # tags = SubFactory(TagFactory)
 
     user = factory.SubFactory("backend.users.tests.factories.UserFactory", profile=None)
 
@@ -90,8 +106,6 @@ class ProfileFactory(DjangoModelFactory):
 class FakePhotoProfileFactory(ProfileFactory):
 
     photo = ImageFieldFactory(from_func=generated_profile_photo)
-
-    tags = []
 
     class Meta:
         model = Profile

--- a/backend/backend/users/tests/test_drf_views.py
+++ b/backend/backend/users/tests/test_drf_views.py
@@ -17,11 +17,11 @@ class TestProfileViewSet:
 
         assert profile in view.get_queryset()
 
-    @pytest.mark.only
-    def test_me(self, profile: Profile, rf: RequestFactory):
+
+    def test_me(self, profile_with_tags: Profile, rf: RequestFactory):
         view = ProfileViewSet()
         request = rf.get("/fake-url/")
-        request.user = profile.user
+        request.user = profile_with_tags.user
 
         view.request = request
         response = view.me(request)
@@ -36,15 +36,14 @@ class TestProfileViewSet:
             "linkedin",
             "visible",
         ]:
-            assert response.data[prop] == getattr(profile, prop)
+            assert response.data[prop] == getattr(profile_with_tags, prop)
 
         # we need to check separately for tags, as they use
         # their own manager
-        response.data['tags'] = [tag for tag in profile.tags.all()]
+        response.data['tags'] = [tag for tag in profile_with_tags.tags.all()]
 
 
-    @pytest.mark.only
-    def test_data_structure(self, profile: Profile, rf: RequestFactory):
+    def test_tag_serialised_data_structure(self, profile: Profile, rf: RequestFactory):
         view = ProfileViewSet()
         request = rf.get("/fake-url/")
         request.user = profile.user
@@ -63,7 +62,6 @@ class TestProfileViewSet:
                 assert k in tag.keys()
 
 
-    @pytest.mark.only
     def test_create_profile(self, profile: Profile, rf: RequestFactory):
         view = ProfileViewSet()
         request = rf.get("/fake-url/")
@@ -79,7 +77,7 @@ class TestProfileViewSet:
 
             'name': 'Long Name with lots of letters',
             'email': 'email@somesite.com',
-            'tags': ["tech"],
+            'tags': ["tech, 'something else'', "],
 
             'bio': 'Themselves TV western under. Tv can beautiful we throughout politics treat both. Fear speech left get answer over century.',
 
@@ -90,29 +88,6 @@ class TestProfileViewSet:
 
         response = view.create(request)
         assert response.status_code == 201
-
-    @pytest.mark.only
-        expected_fields = [
-            'id',
-
-            'name',
-            'email',
-
-            'phone',
-            'website',
-            'twitter',
-            'facebook',
-            'linkedin',
-
-            'tags',
-            'bio',
-            'admin',
-            'visible',
-            'photo'
-        ]
-
-        for field in expected_fields:
-            assert field in response.data.keys()
 
 
     def test_update_profile(self, profile: Profile, rf: RequestFactory):

--- a/backend/backend/users/tests/test_serializer.py
+++ b/backend/backend/users/tests/test_serializer.py
@@ -85,3 +85,22 @@ class TestProfileSerializer:
 
         # and has the profile been updated?
         assert res.bio == profile_dict['bio']
+    def test_update_profile_tags(self, profile):
+
+        assert profile.tags.count() == 0
+
+        profile_dict = {
+            "tags": ["tech"],
+        }
+
+        ps = ProfileSerializer(data=profile_dict)
+        assert ps.is_valid()
+
+        res = ps.update(profile, ps.data)
+
+        new_ps = ProfileSerializer(res)
+        new_data = new_ps.data
+
+        assert res.tags.first().name == "tech"
+        assert res.tags.first().name == "tech"
+

--- a/backend/config/settings/local.py
+++ b/backend/config/settings/local.py
@@ -60,6 +60,8 @@ INSTALLED_APPS += ["django_extensions"]  # noqa F405
 # ------------------------------------------------------------------------------
 CORS_ORIGIN_WHITELIST = [
     "http://localhost:8081",
-    "http://127.0.0.1:8081"
+    "http://127.0.0.1:8081",
+    "http://localhost:8080",
+    "http://127.0.0.1:8080",
 ]
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
This PR introduces the necessary code to actually save tags sent via the API.

Previously, we were saving other properties, but we needed to call some methods in the Tag handling subclass in the correct order, to make sure they were saved to the database and presented properly in the serialised responses in our JSON.