### PR TITLE
Fix tags errors in Vue

### DIFF
--- a/cl8-web/src/components/profile/ProfileTagsComponent.vue
+++ b/cl8-web/src/components/profile/ProfileTagsComponent.vue
@@ -26,7 +26,9 @@ export default {
       return this.data || []
     },
     sortedOptions: function() {
-      return sortBy(this.options, function(x){ return x.name.toLowerCase() })
+      return sortBy(this.options, function(x){
+        return x.name ? x.name.toLowerCase() : x.toLowerCase()
+      })
     }
   },
   data: () => {

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -317,11 +317,17 @@ const actions = {
     const token = context.getters.token
     const profileId = payload.id
 
-    await instance.put(`/api/profiles/${profileId}/`, payload, {
+    const profile = await instance.put(`/api/profiles/${profileId}/`, payload, {
       headers: { Authorization: `Token ${token}` }
     })
 
-    router.push({ name: 'home' })
+    if (profile) {
+      context.commit('SET_PROFILE', profile.data)
+      context.dispatch('fetchVisibleProfileList')
+      router.push({ name: 'home' })
+    } else {
+      return 'There was a problem saving changes to the profile.'
+    }
 
     // if (!pushKey) {
     //   throw new Error(


### PR DESCRIPTION
This PR addresses the errors in the console when attempting to update profiles.

Specifically, it adds a ternary for displaying tags (`tag.name` when tag is an object, otherwise `tag`), and changes the updateProfile action to refresh state.