### PR TITLE
Use specific function for checking for authed users

### DIFF
--- a/cl8-web/src/App.vue
+++ b/cl8-web/src/App.vue
@@ -1,11 +1,12 @@
 <template>
-  <div id="app" class="cf center w-100 mw8 system-sans-serif">
+  <div id="app" class="cf center w-100 mw8 system-sans-serif sans-serif">
     <router-view></router-view>
   </div>
 </template>
 
 <script>
 import debugLib from 'debug'
+import { fetchCurrentUser } from './utils'
 // eslint-disable-next-line
 const debug = debugLib('cl8.App')
 
@@ -15,7 +16,18 @@ export default {
   data() {
     return {}
   },
-  methods: {}
+  methods: {},
+  async mounted() {
+    // if a user is not logged in, push to the login
+    debug('mounted')
+    const currentUser = await fetchCurrentUser(this.$store)
+
+    if (!currentUser) {
+      this.$router.push({name: 'signin'})
+    }
+  }
+
+
 }
 </script>
 

--- a/cl8-web/src/components/TheHomePanel.vue
+++ b/cl8-web/src/components/TheHomePanel.vue
@@ -47,10 +47,7 @@ export default {
     }
   },
   watch: {},
-  methods: {},
-  created() {
-    debug('created')
-  }
+  methods: {}
 }
 </script>
 

--- a/cl8-web/src/components/profile/ProfileDetail.vue
+++ b/cl8-web/src/components/profile/ProfileDetail.vue
@@ -99,7 +99,7 @@ const debug = debugLib('cl8.ProfileDetail')
 
 Vue.component('v-gravatar', Gravatar)
 
-import linkify from '../../utils'
+import { linkify } from '../../utils'
 
 export default {
   name: 'ProfileDetail',

--- a/cl8-web/src/utils.js
+++ b/cl8-web/src/utils.js
@@ -1,3 +1,6 @@
+import debugLib from 'debug'
+const debug = debugLib('cl8.utils')
+
 function linkify (url, prefix) {
   // check if link already starts with 'http:', return if so
   let pattern = RegExp(/https?:/)
@@ -12,4 +15,19 @@ function linkify (url, prefix) {
   return `http://${url}`
 }
 
-export default linkify
+async function fetchCurrentUser(store) {
+  debug('currentProfile', store.getters.currentUser)
+  if (!localStorage.token) {
+    return false
+  }
+  if (!store.getters.currentUser && localStorage.token) {
+    await store.dispatch('createUserSession')
+  }
+
+  return store.getters.currentUser
+}
+
+export {
+  linkify,
+  fetchCurrentUser
+}

--- a/cl8-web/tests/unit/specs/checkLink.spec.js
+++ b/cl8-web/tests/unit/specs/checkLink.spec.js
@@ -1,4 +1,4 @@
-import linkify from '../../../src/utils'
+import { linkify } from '../../../src/utils'
 
 describe('Linkify', () => {
   it("adds 'http://' to domain.com if not present", () => {


### PR DESCRIPTION
This PR this extracts the auth check we make to a separate utils function, so we can use it in multiple plces, and 
uses it in the bootstrap phrase when starting the Vue app. 

This should address the issue when of users visiting a named route like `/edit/` and so on, when they might not have a user in the Vuex store to refer to. 

This also refactors the utils module where we use the linkify function, because it now holds multiple functions.