### PR TITLE
Show inactive tags in tag component

### DIFF
--- a/cl8-web/src/components/profile/ProfileEdit.vue
+++ b/cl8-web/src/components/profile/ProfileEdit.vue
@@ -119,7 +119,6 @@
                 <profile-tags-component
                   :data.sync="profile.tags"
                   :options="fullTagList"
-                  @newtag="addTag"
                 ></profile-tags-component>
               </div>
             </div>
@@ -178,17 +177,6 @@ export default {
     await this.$store.dispatch('fetchVisibleProfileList')
   },
   methods: {
-    addTag(newTag) {
-      debug('new tag', newtag)
-      let tempVal =
-        newTag.substring(0, 2) + Math.floor(Math.random() * 10000000)
-      const tag = {
-        name: newTag,
-        code: tempVal,
-        id: 'tempval' + tempVal
-      }
-      this.profile.tags.push(tag)
-    },
     onSubmit: function(item) {
       debug('updating profile', this.profile)
       this.$store.dispatch('updateProfile', this.profile)

--- a/cl8-web/src/components/profile/ProfileEdit.vue
+++ b/cl8-web/src/components/profile/ProfileEdit.vue
@@ -118,7 +118,7 @@
                 </p>
                 <profile-tags-component
                   :data.sync="profile.tags"
-                  :options="profileTags"
+                  :options="fullTagList"
                   @newtag="addTag"
                 ></profile-tags-component>
               </div>
@@ -168,10 +168,18 @@ export default {
     },
     profileTags: function() {
       return this.profile.tags
+    },
+    fullTagList: function() {
+      return this.$store.getters.tagList
     }
+  },
+  async created() {
+    debug('fetching latest profiles and tags')
+    await this.$store.dispatch('fetchVisibleProfileList')
   },
   methods: {
     addTag(newTag) {
+      debug('new tag', newtag)
       let tempVal =
         newTag.substring(0, 2) + Math.floor(Math.random() * 10000000)
       const tag = {

--- a/cl8-web/src/components/profile/ProfileTagsComponent.vue
+++ b/cl8-web/src/components/profile/ProfileTagsComponent.vue
@@ -71,7 +71,7 @@ export default {
         this.list = [val]
       }
       // TODO use the store instead here
-      this.$emit('update:data', this.list)
+      this.$store.dispatch('updateProfileTags', this.list)
     },
     newtag: function(event) {
       debug('new tag submission:', this.input)
@@ -91,9 +91,6 @@ export default {
     checkInList: function(option){
       const that = this
       if (this.list !== undefined) {
-        // debug({option})
-        // debug(JSON.parse(JSON.stringify(option)))
-        // debug(that.options)
         return that.inTagList(option.name)
       } else {
         return false

--- a/cl8-web/src/components/profile/ProfileTagsComponent.vue
+++ b/cl8-web/src/components/profile/ProfileTagsComponent.vue
@@ -14,16 +14,24 @@
 </template>
 <script>
 import { sortBy } from 'lodash'
+import debugLib from 'debug'
+
+const debug = debugLib('cl8.ProfileTagsComponent')
 // TODO
 export default {
   name: 'ProfileTagsComponent',
-  props: ['data', 'options'],
+  props: ['data'],
   created () {
     if (this.list === undefined ) this.list = []
   },
   computed: {
     list: function () {
-      return this.data || []
+      return this.$store.getters.profile.tags
+      // return this.data || []
+    },
+    options: function () {
+      // debug(this.$store.getters.fullTagList
+      return this.$store.getters.fullTagList
     },
     sortedOptions: function() {
       return sortBy(this.options, function(x){
@@ -51,17 +59,27 @@ export default {
       this.$emit('update:data', this.list)
     },
     newtag: function(event, val) {
+      //
       event.preventDefault()
       if (val.length > 0) {
         val = val.toLowerCase().trim()
+        // TODO replaces this with updating the store, instead
+        // of bubbling it up the tree
         if (this.list.find(x => x.name.toLowerCase() === val) === undefined) {
-          this.$emit('newtag', val)
+          this.$store.dispatch('newProfileTag', val)
+
         }
       }
+      // then reset input
+      this.input = ''
     },
     checkInList: function(option){
+      const that = this
       if (this.list !== undefined) {
-        return this.list.filter(x => x.name === option.name).length > 0
+        // debug({option})
+        debug(JSON.parse(JSON.stringify(option)))
+        // debug(that.options)
+        return that.list.filter(x => x.name === option.name).length > 0
       } else {
         return false
       }

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -2,6 +2,7 @@
 import router from './routes'
 import axios from 'axios'
 import { tagList } from './utils'
+import { reject } from 'lodash'
 
 const debug = require('debug')('cl8.store')
 
@@ -70,7 +71,7 @@ const getters = {
     return state.profileList
   },
   fullTagList: function(state) {
-    debug('getting fullTagList:', state.fullTagList)
+    debug('getting fullTagList:', state.fullTagList.length)
     return state.fullTagList
   },
   profileShowing: function(state) {
@@ -141,7 +142,7 @@ const mutations = {
   SET_TAG_LIST: function(state, payload) {
     debug('profiles:', payload)
     state.fullTagList = tagList(payload)
-    debug('tagList:', state.fullTagList)
+    debug('tagList:', state.fullTagList.length)
   } ,
   toggleProfileShowing: function(state) {
     debug('profileShowing', state.profileShowing)
@@ -324,8 +325,38 @@ const actions = {
     } else {
       return 'Something went wrong with uploading the photo.'
     }
-  }
+  },
+  updateProfileList: function(context, payload)   {
+      let profiles = context.getters.visibleProfileList
+      debug(`profiles count: ${profiles.length}`)
+      let newProfileList = reject(profiles, function(prof) {
+        return prof.id === payload.id
+      })
+      debug(`newProfiles count: ${newProfileList.length}`)
+      newProfileList.push(payload)
+      debug(`updated newProfiles count: ${newProfileList.length}`)
+      context.commit('setVisibleProfileList', newProfileList)
+      context.commit('SET_TAG_LIST', newProfileList)
+
+  },
+  newProfileTag: async function(context, payload) {
+    debug('new tag', payload)
+    const newTag = payload
+    let tempVal =
+      newTag.substring(0, 2) + Math.floor(Math.random() * 10000000)
+    const tag = {
+      name: newTag,
+      code: tempVal,
+      id: 'tempval' + tempVal
+    }
+    const profile = context.getters.profile
+    profile.tags.push(tag)
+    // const tags = context.getters.fullTagList
+    context.commit('SET_PROFILE', profile)
+    context.dispatch('updateProfileList', profile)
+  },
 }
+
 
 export default {
   state,

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import router from './routes'
 import axios from 'axios'
+import { tagList } from './utils'
 
 const debug = require('debug')('cl8.store')
 
@@ -23,11 +24,12 @@ const state = {
   profileShowing: false,
   profileList: [],
   visibleProfileList: [],
+  fullTagList: '',
   requestUrl: null,
   signInData: {
     message: null,
     email: null
-  }, 
+  },
   token: localStorage.token || null
 }
 
@@ -66,6 +68,10 @@ const getters = {
   profileList: function(state) {
     debug('getting profileList')
     return state.profileList
+  },
+  fullTagList: function(state) {
+    debug('getting fullTagList:', state.fullTagList)
+    return state.fullTagList
   },
   profileShowing: function(state) {
     return state.profileShowing
@@ -132,6 +138,11 @@ const mutations = {
     debug('setVisibleProfileList', payload)
     state.visibleProfileList = payload
   },
+  SET_TAG_LIST: function(state, payload) {
+    debug('profiles:', payload)
+    state.fullTagList = tagList(payload)
+    debug('tagList:', state.fullTagList)
+  } ,
   toggleProfileShowing: function(state) {
     debug('profileShowing', state.profileShowing)
     state.profileShowing = !state.profileShowing
@@ -233,6 +244,8 @@ const actions = {
       debug('profiles resp', response)
       const profileArray = response.data.filter(profile => profile.visible)
       context.commit('setVisibleProfileList', profileArray)
+      context.commit('SET_TAG_LIST', profileArray)
+
     } catch (error) {
       debug('Error fetching visibleProfileList', error)
     }

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -299,6 +299,15 @@ const actions = {
       return 'There was a problem saving changes to the profile.'
     }
   },
+  updateProfileTags: function(context, payload) {
+    // update the profile locally, without saving
+    // given that we have updateProfle above, we may be better
+    // with save Profile to send data to the server and update for local store changes
+    const profile = context.getters.profile
+    profile.tags = payload
+    context.commit('SET_PROFILE', profile)
+    context.dispatch('updateProfileList', profile)
+  },
   updateProfilePhoto: async function(context, payload) {
     const profileId = payload.profile.id
     const token = context.getters.token

--- a/cl8-web/src/utils.js
+++ b/cl8-web/src/utils.js
@@ -1,4 +1,6 @@
 import debugLib from 'debug'
+import lodash from 'lodash'
+
 const debug = debugLib('cl8.utils')
 
 function linkify (url, prefix) {
@@ -27,7 +29,37 @@ async function fetchCurrentUser(store) {
   return store.getters.currentUser
 }
 
+function tagList(profileList) {
+  // Javscript's equality rules mean we need to stringify the objects
+  // to ensure that tags are deduped.
+  // TODO: this seems like a terrible way to check equality - surely there's a better way?
+  debug('profileList', profileList)
+  let tags = new Set()
+  console.log(profileList)
+
+  const profileTags = profileList.map((profile) => {
+    if (profile.tags) {
+      return profile.tags
+    }
+      else return []
+  })
+
+  profileTags.forEach((tagSet) => {
+    tagSet.forEach((tag) => {
+      debug(`adding tag ${tag.name}`)
+      tags.add(JSON.stringify(tag))
+    })
+  })
+  if (tags) {
+    debug('tags', tags)
+    return Array.from(tags).map((tagString) => { return JSON.parse(tagString)})
+  } else {
+    return []
+  }
+}
+
 export {
   linkify,
-  fetchCurrentUser
+  fetchCurrentUser,
+  tagList
 }

--- a/cl8-web/src/utils.js
+++ b/cl8-web/src/utils.js
@@ -35,7 +35,6 @@ function tagList(profileList) {
   // TODO: this seems like a terrible way to check equality - surely there's a better way?
   debug('profileList', profileList)
   let tags = new Set()
-  console.log(profileList)
 
   const profileTags = profileList.map((profile) => {
     if (profile.tags) {

--- a/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
+++ b/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
@@ -97,4 +97,24 @@ describe('ProfileTagsComponent', () => {
     })
     expect(wrapper.findAll('#tags button').length).toBe(8)
   })
+  it('dispatches the "newProfileTag" action when adding a new tag', async () => {
+    const mockStore = {
+      getters: {
+        profile: sampleData,
+        fullTagList: sampleTagList
+      },
+      dispatch: jest.fn()
+    }
+
+    const wrapper = mount(ProfileTagsComponent, {
+      mocks: {
+        $store: mockStore
+      }
+    })
+    wrapper.find("#tags [data-tagname]").setValue("new tag")
+    wrapper.find("#tags [data-tagname]").trigger("keydown.enter")
+
+    await wrapper.vm.$nextTick()
+    expect(mockStore.dispatch).toHaveBeenCalledWith('newProfileTag', 'new tag')
+  })
 })

--- a/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
+++ b/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
@@ -1,0 +1,86 @@
+import Vue from 'vue'
+import { mount } from '@vue/test-utils'
+
+import ProfileTagsComponent from '@/components/profile/ProfileTagsComponent'
+
+let sampleData = {
+  fields: {
+    admin: 'true',
+    bio: '',
+    email: 'someone@domain.com',
+    tags: [
+      {
+        "id": 2,
+        "slug": "web",
+        "name": "web"
+      },
+      {
+        "id": 3,
+        "slug": "scoped-emissions",
+        "name": "scoped emissions"
+      }
+    ],
+    visible: 'yes',
+  },
+  id: 'recxxxxxxxxxxxxxx',
+}
+
+const sampleTagList = [
+  {
+    "id": 2,
+    "slug": "web",
+    "name": "web"
+  },
+  {
+    "id": 3,
+    "slug": "scoped-emissions",
+    "name": "scoped emissions"
+  },
+  {
+    "id": 5,
+    "slug": "sustainable-software-engineering",
+    "name": "sustainable software engineering"
+  },
+  {
+    "id": 6,
+    "slug": "dgen",
+    "name": "dgen"
+  },
+  {
+    "id": 7,
+    "slug": "python",
+    "name": "python"
+  },
+  {
+    "id": 8,
+    "slug": "carbon",
+    "name": "carbon"
+  },
+  {
+    "id": 9,
+    "slug": "javascript",
+    "name": "javascript"
+  },
+  {
+    "id": 10,
+    "slug": "community-management",
+    "name": "community management"
+  }
+]
+
+describe('ProfileTagsComponent', () => {
+  it('shows a list of active tags', () => {
+    const wrapper = mount(ProfileTagsComponent, {
+      propsData: { data: sampleData.fields.tags, options: sampleTagList }
+    })
+    expect(wrapper.findAll('#tags button.active').length).toBe(2)
+    // expect(wrapper.findAll('.gravatar').length).toBe(0)
+  })
+  it('shows a list of inactive tags too', () => {
+    const wrapper = mount(ProfileTagsComponent, {
+      propsData: { data: sampleData.fields.tags, options: sampleTagList}
+    })
+    expect(wrapper.findAll('#tags button').length).toBe(8)
+    // expect(wrapper.findAll('.gravatar').length).toBe(1)
+  })
+})

--- a/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
+++ b/cl8-web/tests/unit/specs/ProfileTagsComponent.spec.js
@@ -1,10 +1,13 @@
-import Vue from 'vue'
-import { mount } from '@vue/test-utils'
+
+import { mount} from '@vue/test-utils'
 
 import ProfileTagsComponent from '@/components/profile/ProfileTagsComponent'
 
+import debugLib from 'debug'
+
+const debug = debugLib('cl8.ProfileTagsComponent.spec')
+
 let sampleData = {
-  fields: {
     admin: 'true',
     bio: '',
     email: 'someone@domain.com',
@@ -21,8 +24,7 @@ let sampleData = {
       }
     ],
     visible: 'yes',
-  },
-  id: 'recxxxxxxxxxxxxxx',
+    id: 'recxxxxxxxxxxxxxx',
 }
 
 const sampleTagList = [
@@ -71,16 +73,28 @@ const sampleTagList = [
 describe('ProfileTagsComponent', () => {
   it('shows a list of active tags', () => {
     const wrapper = mount(ProfileTagsComponent, {
-      propsData: { data: sampleData.fields.tags, options: sampleTagList }
+      mocks: {
+        $store: {
+          getters: {
+            profile: sampleData,
+            fullTagList: sampleTagList
+          }
+        }
+      }
     })
     expect(wrapper.findAll('#tags button.active').length).toBe(2)
-    // expect(wrapper.findAll('.gravatar').length).toBe(0)
   })
   it('shows a list of inactive tags too', () => {
     const wrapper = mount(ProfileTagsComponent, {
-      propsData: { data: sampleData.fields.tags, options: sampleTagList}
+      mocks: {
+        $store: {
+          getters: {
+            profile: sampleData,
+            fullTagList: sampleTagList
+          }
+        }
+      }
     })
     expect(wrapper.findAll('#tags button').length).toBe(8)
-    // expect(wrapper.findAll('.gravatar').length).toBe(1)
   })
 })

--- a/cl8-web/tests/unit/specs/profileTags.spec.js
+++ b/cl8-web/tests/unit/specs/profileTags.spec.js
@@ -1,0 +1,39 @@
+import { tagList } from '../../../src/utils'
+
+
+const profiles = [{
+  "tags": [
+    {
+      "id": 2,
+      "slug": "web",
+      "name": "web"
+    },
+  ],
+},
+{
+  "tags": [
+    {
+      "id": 2,
+      "slug": "web",
+      "name": "web"
+    }
+  ]
+}]
+
+describe('taglist', () => {
+  describe('given a list of profiles', () => {
+    it('it returns a list of unique tags', () => {
+      const tags = tagList(profiles)
+      expect(tags).toHaveLength(1)
+      expect(tags[0].id).toBe(2)
+      expect(tags[0].slug).toBe('web')
+      expect(tags[0].name).toBe('web')
+    })
+  })
+  describe('given a list of profiles with no tags', () => {
+    it('should return an empty array', () => {
+      const tags = tagList([{},{}])
+      expect(tags).toHaveLength(0)
+    })
+  })
+})

--- a/cl8-web/tests/unit/specs/store.spec.js
+++ b/cl8-web/tests/unit/specs/store.spec.js
@@ -103,9 +103,49 @@ describe("Store/Actions/newProfileTag", () => {
     store.commit('setProfileList', visibleProfileList)
     store.dispatch('newProfileTag', 'new tag')
     expect(store.state.fullTagList).toHaveLength(2)
+  })
+}),
+describe("Store/Actions/updateProfileTags", () => {
+  it("adds an active tag to a profile", async () => {
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    const sampleProfile = {
+      "id": 1,
+      "name":"sample_user",
+      "tags": []
+    }
+    const store = new Vuex.Store(Store)
+    store.commit('SET_PROFILE', sampleProfile)
+    store.commit('setProfileList', [sampleProfile])
+    store.dispatch('updateProfileTags', [
+      {
+        "id": 2,
+        "slug": "web",
+        "name": "web"
+      },
+    ])
+    expect(store.state.fullTagList).toHaveLength(1)
+  })
+  it("removes tags no longer on a profile", async () => {
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    const sampleProfile = {
+      "id": 1,
+      "name":"sample_user",
+      "tags": [
+        {
+          "id": 2,
+          "slug": "web",
+          "name": "web"
+        },
+      ],
+    }
+    const store = new Vuex.Store(Store)
+    store.commit('SET_PROFILE', sampleProfile)
+    store.commit('setProfileList', [sampleProfile])
+    store.dispatch('updateProfileTags', [])
+    expect(store.state.fullTagList).toHaveLength(0)
 
-
-    // check that after we add new tag, the getter is returning the expected updated value
   })
 })
 

--- a/cl8-web/tests/unit/specs/store.spec.js
+++ b/cl8-web/tests/unit/specs/store.spec.js
@@ -42,7 +42,7 @@ describe('Store/Getters/tagList', () => {
     const localVue = createLocalVue()
     localVue.use(Vuex)
     // console.log(Store.state)
-    Store.state.visibleProfileList = [{
+    const visibleProfileList = [{
       "tags": [
         {
           "id": 2,
@@ -64,11 +64,48 @@ describe('Store/Getters/tagList', () => {
     // console.log(Store.state)
     const store = new Vuex.Store(Store)
     // call action
-    await store.dispatch('fetchVisibleProfileList')
+    // await store.dispatch('fetchVisibleProfileList')
+    store.commit('SET_TAG_LIST', visibleProfileList)
     // assert we have what we think we have
-    expect(store.state.visibleProfileList).toHaveLength(2)
+    // expect(store.state.visibleProfileList).toHaveLength(2)
     expect(store.state.fullTagList).toHaveLength(1)
   })
+}),
+describe("Store/Actions/newProfileTag", () => {
+  it("adds a tag to a profile", async () => {
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    // console.log(Store.state)
+    const visibleProfileList = [{
+      "id": 1,
+      "name":"sample_user",
+      "tags": [
+        {
+          "id": 2,
+          "slug": "web",
+          "name": "web"
+        },
+      ],
+    },
+    {
+      "id": 1,
+      "name":"second sample_user",
+      "tags": [
+        {
+          "id": 2,
+          "slug": "web",
+          "name": "web"
+        }
+      ]
+    }]
+    const store = new Vuex.Store(Store)
+    store.commit('SET_PROFILE', visibleProfileList[0])
+    store.commit('setProfileList', visibleProfileList)
+    store.dispatch('newProfileTag', 'new tag')
+    expect(store.state.fullTagList).toHaveLength(2)
 
+
+    // check that after we add new tag, the getter is returning the expected updated value
+  })
 })
 

--- a/cl8-web/tests/unit/specs/store.spec.js
+++ b/cl8-web/tests/unit/specs/store.spec.js
@@ -35,3 +35,40 @@ describe.skip('Store/Actions/fetchVisibleUserList', () => {
 
   describe.skip('not authed', () => {})
 })
+
+describe('Store/Getters/tagList', () => {
+  it("returns a list of unique tags from a list of profiles", async () => {
+    //  instantivate Vue
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    // console.log(Store.state)
+    Store.state.visibleProfileList = [{
+      "tags": [
+        {
+          "id": 2,
+          "slug": "web",
+          "name": "web"
+        },
+      ],
+    },
+    {
+      "tags": [
+        {
+          "id": 2,
+          "slug": "web",
+          "name": "web"
+        }
+      ]
+    }]
+
+    // console.log(Store.state)
+    const store = new Vuex.Store(Store)
+    // call action
+    await store.dispatch('fetchVisibleProfileList')
+    // assert we have what we think we have
+    expect(store.state.visibleProfileList).toHaveLength(2)
+    expect(store.state.fullTagList).toHaveLength(1)
+  })
+
+})
+

--- a/cl8-web/tests/unit/specs/store.spec.js
+++ b/cl8-web/tests/unit/specs/store.spec.js
@@ -5,13 +5,13 @@ import Vuex from 'vuex'
 describe.skip('Store/Actions/fetchUserList', () => {
   describe('authed', () => {
     it('fetches a list of users from our API server ', async () => {
-      //  instantivate Vue
+      //  arrange
       const localVue = createLocalVue()
       localVue.use(Vuex)
       const store = new Vuex.Store(Store)
-      // call action
+      // act
       await store.dispatch('fetchProfileList')
-      // assert we have what we think we have
+      // assert
       expect(store.state.profileList).toHaveLength(3)
     })
   })
@@ -22,13 +22,13 @@ describe.skip('Store/Actions/fetchUserList', () => {
 describe.skip('Store/Actions/fetchVisibleUserList', () => {
   describe('authed', () => {
     it('fetches a list of visible users from our API server ', async () => {
-      //  instantivate Vue
+      //  arrange
       const localVue = createLocalVue()
       localVue.use(Vuex)
       const store = new Vuex.Store(Store)
-      // call action
+      // act
       await store.dispatch('fetchVisibleProfileList')
-      // assert we have what we think we have
+      // assert
       expect(store.state.visibleProfileList).toHaveLength(2)
     })
   })
@@ -38,10 +38,10 @@ describe.skip('Store/Actions/fetchVisibleUserList', () => {
 
 describe('Store/Getters/tagList', () => {
   it("returns a list of unique tags from a list of profiles", async () => {
-    //  instantivate Vue
+
     const localVue = createLocalVue()
     localVue.use(Vuex)
-    // console.log(Store.state)
+
     const visibleProfileList = [{
       "tags": [
         {
@@ -61,13 +61,8 @@ describe('Store/Getters/tagList', () => {
       ]
     }]
 
-    // console.log(Store.state)
     const store = new Vuex.Store(Store)
-    // call action
-    // await store.dispatch('fetchVisibleProfileList')
     store.commit('SET_TAG_LIST', visibleProfileList)
-    // assert we have what we think we have
-    // expect(store.state.visibleProfileList).toHaveLength(2)
     expect(store.state.fullTagList).toHaveLength(1)
   })
 }),
@@ -75,7 +70,7 @@ describe("Store/Actions/newProfileTag", () => {
   it("adds a tag to a profile", async () => {
     const localVue = createLocalVue()
     localVue.use(Vuex)
-    // console.log(Store.state)
+
     const visibleProfileList = [{
       "id": 1,
       "name":"sample_user",


### PR DESCRIPTION
This PR:

- displays unused tags by other members
- switches the profile tag component to use the Vuex store
- moves logic out of the component in favour of having it in the store, or a separate utils file
- adds tests at the store level for the main logic, and the component for handling user interactions and presenting stuff
- adds interaction fixes to submitting views