### PR TITLE
Update TheProfileList to show profiles again

### DIFF
--- a/backend/backend/templates/flatpages/default.html
+++ b/backend/backend/templates/flatpages/default.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
-    <title>{% block title %}{{ flatpage.content }}{% endblock title %}</title>
+    <title>
+    {% block title %}
+        {{ flatpage.title }}
+    {% endblock title %}
+    </title>
 
 {% block content %}
         {{ flatpage.content }}

--- a/cl8-web/src/components/TheProfileList.vue
+++ b/cl8-web/src/components/TheProfileList.vue
@@ -74,16 +74,16 @@ export default {
     this.$store.commit('startLoading')
 
     // make a new promise to fetch this stuff, then after they have loaded show the stuff
-    await this.$store.dispatch('fetchprofileList')
-
-    debug('loaded the profiles in the component')
-    this.searchResults = this.profileList
-    this.$store.commit('stopLoading')
-    this.loading = false
-
-    // .catch(err => {
-    //   debug("couldn't load in the profile: ", err)
-    // })
+    try {
+      await this.$store.dispatch('fetchprofileList')
+      debug('loaded the profiles in the component')
+      this.searchResults = this.profileList
+      this.$store.commit('stopLoading')
+      this.loading = false
+    }
+    catch (e) {
+      debug("couldn't load in the profile: ", e)
+    }
   },
 
   methods: {

--- a/cl8-web/src/components/TheProfileList.vue
+++ b/cl8-web/src/components/TheProfileList.vue
@@ -7,7 +7,7 @@
     </div>
 
     <div v-else>
-      <div class="tag-list pa2 bb b--light-gray" v-if="activeTags.length>0">
+      <div class="tag-list pa2 bb b--light-gray" v-if="activeTags">
         <p>
           <button
             v-for="tag in activeTags"

--- a/cl8-web/src/components/TheProfileList.vue
+++ b/cl8-web/src/components/TheProfileList.vue
@@ -57,8 +57,8 @@ export default {
     activeTags() {
       return this.$store.getters.activeTags
     },
-    visibleProfiles() {
-      return this.$store.getters.visibleProfileList
+    profileList() {
+      return this.$store.getters.profileList
     }
   },
   watch: {
@@ -69,22 +69,21 @@ export default {
       this.checkAgainstSearch()
     }
   },
-  created() {
+  async created() {
     debug('created')
     this.$store.commit('startLoading')
 
     // make a new promise to fetch this stuff, then after they have loaded show the stuff
-    this.$store
-      .dispatch('fetchVisibleProfileList')
-      .then(() => {
-        debug('loaded the profiles in the component')
-        this.searchResults = this.visibleProfiles
-        this.$store.commit('stopLoading')
-        this.loading = false
-      })
-      .catch(err => {
-        debug("couldn't load in the profile: ", err)
-      })
+    await this.$store.dispatch('fetchprofileList')
+
+    debug('loaded the profiles in the component')
+    this.searchResults = this.profileList
+    this.$store.commit('stopLoading')
+    this.loading = false
+
+    // .catch(err => {
+    //   debug("couldn't load in the profile: ", err)
+    // })
   },
 
   methods: {
@@ -112,9 +111,9 @@ export default {
       const terms = this.activeTags
       debug('matchingTags', terms)
       if (typeof terms === 'undefined' || terms === '') {
-        return this.visibleProfiles
+        return this.profileList
       }
-      const availableProfiles = this.visibleProfiles
+      const availableProfiles = this.profileList
       debug('availableProfiles', availableProfiles)
       // clear out profiles with NO tags
       let profilesWithTags = availableProfiles.filter(function(profile) {

--- a/cl8-web/src/store.js
+++ b/cl8-web/src/store.js
@@ -24,7 +24,7 @@ const state = {
   profile: null,
   profilePhoto: null,
   profileShowing: false,
-  visibleProfileList: [],
+  profileList: [],
   // fullTagList: '',
   requestUrl: null,
   signInData: {
@@ -43,11 +43,11 @@ const getters = {
   },
   isAdmin: function(state) {
     if (state.user == null) return false
-    if (state.visibleProfileList == null) return false
+    if (state.profileList == null) return false
 
     // Legacy profiles from Airtable have 'yes' in the admin field
     const truthy = ['yes', true]
-    return state.visibleProfileList
+    return state.profileList
       .filter(profile => truthy.includes(profile.admin))
       .map(profile => profile.id)
       .includes(state.user.id)
@@ -67,15 +67,15 @@ const getters = {
   },
   profileList: function(state) {
     debug('getting profileList')
-    return state.visibleProfileList
+    return state.profileList
   },
   fullTagList: function(state) {
     // we add the profile again, in case there
     // are new tags added to them
     if (state.profile)
-      return tagList(state.visibleProfileList.concat([state.profile]))
+      return tagList(state.profileList.concat([state.profile]))
     else {
-      return tagList(state.visibleProfileList)
+      return tagList(state.profileList)
     }
   },
   profileShowing: function(state) {
@@ -138,7 +138,7 @@ const mutations = {
   },
   SET_VISIBLE_PROFILE_LIST: function(state, payload) {
     debug('SET_VISIBLE_PROFILE_LIST', payload)
-    state.visibleProfileList = payload
+    state.profileList = payload
   },
   toggleProfileShowing: function(state) {
     debug('profileShowing', state.profileShowing)
@@ -240,8 +240,8 @@ const actions = {
       debug('Error fetching profileList', error)
     }
   },
-  fetchVisibleProfileList: async function(context) {
-    debug('action:fetchVisibleProfileList')
+  fetchprofileList: async function(context) {
+    debug('action:fetchprofileList')
     try {
       const response = await instance.get('/api/profiles', {
         headers: { Authorization: `Token ${localStorage.token}` }
@@ -252,7 +252,7 @@ const actions = {
 
 
     } catch (error) {
-      debug('Error fetching visibleProfileList', error)
+      debug('Error fetching profileList', error)
     }
   },
   addUser: async function(context, payload) {
@@ -266,7 +266,7 @@ const actions = {
       headers: { Authorization: `Token ${token}` }
     })
     if (response.data) {
-      context.dispatch('fetchVisibleProfileList')
+      context.dispatch('fetchprofileList')
       context.commit('SET_PROFILE', response.data)
       router.push({ name: 'home' })
     } else {
@@ -309,7 +309,7 @@ const actions = {
 
     if (profile) {
       context.commit('SET_PROFILE', profile.data)
-      context.dispatch('fetchVisibleProfileList')
+      context.dispatch('fetchprofileList')
       router.push({ name: 'home' })
     } else {
       return 'There was a problem saving changes to the profile.'

--- a/cl8-web/tests/unit/specs/TheProfileList.spec.js
+++ b/cl8-web/tests/unit/specs/TheProfileList.spec.js
@@ -1,0 +1,112 @@
+import Vue from 'vue'
+import { mount, createLocalVue } from '@vue/test-utils'
+import VueRouter from 'vue-router'
+
+
+import TheProfileList from '@/components/TheProfileList.vue'
+import debugLib from 'debug'
+const debug = debugLib('cl8.TheProfileList.spec')
+
+let sampleData = [{
+  admin: 'true',
+  bio: '',
+  email: 'someone@domain.com',
+  visible: 'yes',
+  id: 'rec1a',
+  tags: [
+    {
+      "id": 2,
+      "slug": "web",
+      "name": "web"
+    },
+    {
+      "id": 3,
+      "slug": "scoped-emissions",
+      "name": "scoped emissions"
+    }
+  ],
+},
+{
+  admin: false,
+  bio: '',
+  email: 'someone.else@domain.com',
+  visible: 'yes',
+  id: 'rec2',
+  tags: [
+    {
+      "id": 2,
+      "slug": "web",
+      "name": "web"
+    },
+    {
+      "id": 3,
+      "slug": "scoped-emissions",
+      "name": "scoped emissions"
+    },
+    {
+      "id": 5,
+      "slug": "sustainable-software-engineering",
+      "name": "sustainable software engineering"
+    },
+    {
+      "id": 6,
+      "slug": "dgen",
+      "name": "dgen"
+    },
+    {
+      "id": 7,
+      "slug": "python",
+      "name": "python"
+    },
+    {
+      "id": 8,
+      "slug": "carbon",
+      "name": "carbon"
+    },
+    {
+      "id": 9,
+      "slug": "javascript",
+      "name": "javascript"
+    },
+    {
+      "id": 10,
+      "slug": "community-management",
+      "name": "community management"
+    }
+  ]
+}]
+
+
+describe('TheProfileList', () => {
+  let wrapper, mockStore
+
+  beforeEach(() => {
+    mockStore = {
+      getters: {
+        profileList: sampleData,
+      },
+      dispatch: jest.fn(),
+      commit: jest.fn()
+    }
+
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    const router = new VueRouter()
+
+    wrapper = mount(TheProfileList, {
+      localVue,
+      mocks: {
+        $store: mockStore,
+        stubs: ['router-view']
+      },
+
+    })
+  })
+  it('renders the component', async () => {
+    expect(wrapper.html()).toBeTruthy()
+  })
+  it('renders a list of profiles', async () => {
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.findAll('.list .peep').length).toBe(2)
+  })
+})

--- a/cl8-web/tests/unit/specs/__snapshots__/LoginComponent.spec.js.snap
+++ b/cl8-web/tests/unit/specs/__snapshots__/LoginComponent.spec.js.snap
@@ -21,8 +21,7 @@ exports[`Login.Vue mounting with expected data shows login form when loaded 1`] 
         </div>
         <!---->
         <form class="w-100 pa3 dib border-box mw6 ph5">
-          <p class="gray measure tl lh-copy">Enter the email address you signed up with to sign in. We'll send a one time login code, to finish logging in.</p>
-          <p class="gray measure tl lh-copy">No passwords needed. </p>
+          <p class="gray measure tl lh-copy">Enter the email address you signed up with to sign in. We'll send a one time login code, to finish logging you in.</p>
           <div class="w-100 mb3"><input type="text" name="email" placeholder="your email address" aria-label="your email address" autocomplete="email" class="input-reset br2 pa2 ba b--light-gray mt1 w-100">
             <div>
               <!---->

--- a/cl8-web/tests/unit/specs/store.spec.js
+++ b/cl8-web/tests/unit/specs/store.spec.js
@@ -6,14 +6,14 @@ enableAutoDestroy(afterEach)
 
 describe('Store/Getters/tagList', () => {
 
-  let localVue, visibleProfileList, store
+  let localVue, profileList, store
 
   beforeEach(() => {
 
     localVue = createLocalVue()
     localVue.use(Vuex)
 
-    visibleProfileList = [{
+    profileList = [{
       "tags": [
         {
           "id": 2,
@@ -33,7 +33,7 @@ describe('Store/Getters/tagList', () => {
     }]
 
   store = new Vuex.Store(Store)
-  store.commit('SET_VISIBLE_PROFILE_LIST', visibleProfileList)
+  store.commit('SET_VISIBLE_PROFILE_LIST', profileList)
   })
 
   it("returns a list of unique tags from a list of profiles", async () => {
@@ -67,9 +67,9 @@ describe.skip('Store/Actions/fetchVisibleUserList', () => {
       localVue.use(Vuex)
       const store = new Vuex.Store(Store)
       // act
-      await store.dispatch('fetchVisibleProfileList')
+      await store.dispatch('fetchprofileList')
       // assert
-      expect(store.state.visibleProfileList).toHaveLength(2)
+      expect(store.state.profileList).toHaveLength(2)
     })
   })
 
@@ -103,7 +103,7 @@ describe.skip("Store/Actions/newProfileTag", () => {
   const localVue = createLocalVue()
     localVue.use(Vuex)
 
-    const visibleProfileList = [{
+    const profileList = [{
       "id": 1,
       "name":"sample_user",
       "tags": [
@@ -126,8 +126,8 @@ describe.skip("Store/Actions/newProfileTag", () => {
       ]
     }]
     const store = new Vuex.Store(Store)
-    store.commit('SET_PROFILE', visibleProfileList[0])
-    store.commit('setProfileList', visibleProfileList)
+    store.commit('SET_PROFILE', profileList[0])
+    store.commit('setProfileList', profileList)
     store.dispatch('newProfileTag', 'new tag')
     expect(store.state.fullTagList).toHaveLength(2)
     expect(store.state.profile.tags).toHaveLength(2)


### PR DESCRIPTION
This PR

- removes the idea of a visible profile list, as we now mostly rely on Django Admin for admin activity
- adds tests for the display of profiles on the component 
- update all references to visibleProfile list
- adds async / await in some functions for readability

### TODO

- [x] add the try / 'catch' back in statement for listing users now that we're using async/await