### PR TITLE
Add pytest for backend tests

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -1,0 +1,52 @@
+name: Django CI
+
+on: [push]
+
+defaults:
+  run:
+    working-directory: ./backend
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: backend
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install pipenv
+        pipenv install --dev
+    - name: Install node dependencies (mjml etc)
+      run: npm install
+      working-directory: ./
+    - name: Run tests
+      run: |
+          pipenv run "pytest -x"
+      env:
+        CI: true
+        DATABASE_URL: "postgres://postgres:postgres@localhost:5432/backend"
+        VUE_APP_SUPPORT_EMAIL: "support@domain.com"
+

--- a/backend/backend/users/tests/generated-sample-data.csv
+++ b/backend/backend/users/tests/generated-sample-data.csv
@@ -1,0 +1,8 @@
+name,admin,visible,tags,photo,email,phone,website,twitter,linkedin,facebook,blurb
+Walton Little,false,true,"government, policy",,Dean95@hotmail.com,,,,,,
+Cristobal Sipes,false,true,"creative, design",,Lucinda.Jakubowski@gmail.com,,philpottdesign.com,,,,
+Ms. Toby Carter,false,true,"entrepreneur, Non-exec director",,Dawson_Rolfson@yahoo.com,,,,,,
+Filomena Casper,false,true,"Non-exec director,entrepreneur",,Benny82@yahoo.com,,,,,,
+Abe Simonis,false,true,"LiveCoding, Music, tech",,Nick1@gmail.com,,slab.org,,,,
+Darion Mosciski,false,true,"climate change, environment, writing",,Arnaldo26@hotmail.com,,,,,,
+Eileen Halvorson,false,true,"writing,environment,climate change",,Irving_Little45@gmail.com,,,,,,


### PR DESCRIPTION
This PR brings the backend under CI as well, running tests with Pytest.

We also add the missing sample data used for some tests running locally.

We probably don't need this in the long run, and we might be able to replace the csv file with a pytest fixture instead. It makes sense to do that when we add some build caching behaviour to speed up these tests.

I've created issue #95, as a reminder to do this.
