### PR TITLE
Add jest axe

### DIFF
--- a/cl8-web/tests/unit/specs/SearchViewComponent.spec.js
+++ b/cl8-web/tests/unit/specs/SearchViewComponent.spec.js
@@ -3,6 +3,9 @@ import { mount } from '@vue/test-utils'
 
 import ProfileSearchItem from '@/components/profile/ProfileSearchItem.vue'
 
+const { axe, toHaveNoViolations } = require('jest-axe')
+expect.extend(toHaveNoViolations)
+
 let sampleData = {
   "fields": {
     "admin": "true",
@@ -68,5 +71,12 @@ describe.skip('ProfileSearchItem', () => {
     })
     expect(wrapper.findAll('img.supplied-photo').length).toBe(0)
     expect(wrapper.findAll('.gravatar').length).toBe(1)
+  })
+  it('passes a11y', async() => {
+    let wrapper = mount(ProfileSearchItem, {
+      propsData: { item: sampleData }
+    })
+    const results = await axe(wrapper.element)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3755,6 +3755,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axe-core": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "dev": true
+    },
     "axios": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
@@ -9778,6 +9784,155 @@
         }
       }
     },
+    "jest-axe": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-3.5.0.tgz",
+      "integrity": "sha512-9U68Os+SPLfL/5X8x9SjX4XxB02BxkFgYBQFDlF8zhpJc0+DZUq54l4NnwA4S4+nYw5CmXvnLjgoNiWpf0G80w==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.5.5",
+        "chalk": "^4.0.0",
+        "jest-matcher-utils": "^26.0.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.3.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.4.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-changed-files": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
@@ -11513,8 +11668,24 @@
                 "js-beautify": "^1.6.14",
                 "juice": "^5.2.0",
                 "lodash": "^4.17.15",
+                "mjml-migrate": "4.5.0",
                 "mjml-parser-xml": "4.5.0",
                 "mjml-validator": "4.5.0"
+              },
+              "dependencies": {
+                "mjml-migrate": {
+                  "version": "4.5.0",
+                  "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.5.0.tgz",
+                  "integrity": "sha512-zzAKSrGpF+OVoa3GHVS7O2A4WZPLBV/Nrc80MGaLS4hhBbuj2WeUdaugVlIMXRRuhQ+nP+k0fZSM8tonDDjd2w==",
+                  "requires": {
+                    "babel-runtime": "^6.26.0",
+                    "commander": "^2.11.0",
+                    "js-beautify": "^1.6.14",
+                    "lodash": "^4.17.15",
+                    "mjml-core": "4.5.0",
+                    "mjml-parser-xml": "4.5.0"
+                  }
+                }
               }
             },
             "mjml-migrate": {
@@ -11633,8 +11804,24 @@
                 "js-beautify": "^1.6.14",
                 "juice": "^5.2.0",
                 "lodash": "^4.17.15",
+                "mjml-migrate": "4.5.0",
                 "mjml-parser-xml": "4.5.0",
                 "mjml-validator": "4.5.0"
+              },
+              "dependencies": {
+                "mjml-migrate": {
+                  "version": "4.5.0",
+                  "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.5.0.tgz",
+                  "integrity": "sha512-zzAKSrGpF+OVoa3GHVS7O2A4WZPLBV/Nrc80MGaLS4hhBbuj2WeUdaugVlIMXRRuhQ+nP+k0fZSM8tonDDjd2w==",
+                  "requires": {
+                    "babel-runtime": "^6.26.0",
+                    "commander": "^2.11.0",
+                    "js-beautify": "^1.6.14",
+                    "lodash": "^4.17.15",
+                    "mjml-core": "4.5.0",
+                    "mjml-parser-xml": "4.5.0"
+                  }
+                }
               }
             },
             "mjml-migrate": {
@@ -11762,9 +11949,37 @@
             "commander": "^2.11.0",
             "js-beautify": "^1.6.14",
             "lodash": "^4.17.15",
+            "mjml-core": "4.5.0",
             "mjml-parser-xml": "4.5.0"
           },
           "dependencies": {
+            "mjml-core": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.5.0.tgz",
+              "integrity": "sha512-/9M4Dt0f7zaVzP7OJZlqaVWS1ijkoEoF6dKKeiXqRQ3oTvyiTEATHGA5xeifsU4dOzDFhdfFbu54LJOmHdPlVw==",
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "html-minifier": "^3.5.3",
+                "js-beautify": "^1.6.14",
+                "juice": "^5.2.0",
+                "lodash": "^4.17.15",
+                "mjml-parser-xml": "4.5.0",
+                "mjml-validator": "4.5.0"
+              }
+            },
+            "mjml-migrate": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.5.0.tgz",
+              "integrity": "sha512-zzAKSrGpF+OVoa3GHVS7O2A4WZPLBV/Nrc80MGaLS4hhBbuj2WeUdaugVlIMXRRuhQ+nP+k0fZSM8tonDDjd2w==",
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "commander": "^2.11.0",
+                "js-beautify": "^1.6.14",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.5.0",
+                "mjml-parser-xml": "4.5.0"
+              }
+            },
             "mjml-parser-xml": {
               "version": "4.5.0",
               "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.5.0.tgz",
@@ -11773,6 +11988,16 @@
                 "babel-runtime": "^6.26.0",
                 "htmlparser2": "^3.9.2",
                 "lodash": "^4.17.15"
+              }
+            },
+            "mjml-validator": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.5.0.tgz",
+              "integrity": "sha512-Qbyf/VCk3U8ViLCu+VCwGYZVQaJAw5brKW/aXeRRHb10LdhaCF1S0JNIiNyutfnqn92QWdzYt6W+cbcEZIKa9A==",
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "lodash": "^4.17.15",
+                "warning": "^3.0.0"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^7.2.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-vue": "^6.2.2",
+    "jest-axe": "^3.5.0",
     "node-sass": "^4.14.1",
     "sass-loader": "^8.0.2",
     "vue-template-compiler": "^2.6.11"


### PR DESCRIPTION
This PR adds the ability to automatically test for accessibility compliance.

It adds a dev dependency for [jest-axe](https://github.com/nickcolley/jest-axe). This is then added to one of the component specs with deferred tests to provide a template going forward.

In the near future, there should be separate PRs implementing jest-axe for each component spec and addressing any issues.