### PR TITLE
Add importer for CSVs in the Admin UI

### DIFF
--- a/backend/backend/templates/admin_index.html
+++ b/backend/backend/templates/admin_index.html
@@ -1,0 +1,91 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+
+{% block coltype %}colMS{% endblock %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block pretitle %}
+
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+
+{% if app_list %}
+    {% for app in app_list %}
+        <div class="app-{{ app.app_label }} module">
+        <table>
+        <caption>
+            <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+        </caption>
+        {% for model in app.models %}
+            <tr class="model-{{ model.object_name|lower }}">
+            {% if model.admin_url %}
+                <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
+            {% else %}
+                <th scope="row">{{ model.name }}</th>
+            {% endif %}
+
+            {% if model.add_url %}
+                <td><a href="{{ model.add_url }}" class="addlink">{% trans 'Add' %}</a></td>
+            {% else %}
+                <td>&nbsp;</td>
+            {% endif %}
+
+            {% if model.admin_url %}
+                {% if model.view_only %}
+                <td><a href="{{ model.admin_url }}" class="viewlink">{% trans 'View' %}</a></td>
+                {% else %}
+                <td><a href="{{ model.admin_url }}" class="changelink">{% trans 'Change' %}</a></td>
+                {% endif %}
+            {% else %}
+                <td>&nbsp;</td>
+            {% endif %}
+            </tr>
+        {% endfor %}
+        </table>
+        </div>
+    {% endfor %}
+{% else %}
+    <p>{% trans 'You don’t have permission to view or edit anything.' %}</p>
+{% endif %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related">
+    <div class="module" id="recent-actions-module">
+        <h2>{% trans 'Recent actions' %}</h2>
+        <h3>{% trans 'My actions' %}</h3>
+            {% load log %}
+            {% get_admin_log 10 as admin_log for_user user %}
+            {% if not admin_log %}
+            <p>{% trans 'None available' %}</p>
+            {% else %}
+            <ul class="actionlist">
+            {% for entry in admin_log %}
+            <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %}changelink{% endif %}{% if entry.is_deletion %}deletelink{% endif %}">
+                {% if entry.is_deletion or not entry.get_admin_url %}
+                    {{ entry.object_repr }}
+                {% else %}
+                    <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                {% endif %}
+                <br>
+                {% if entry.content_type %}
+                    <span class="mini quiet">{% filter capfirst %}{{ entry.content_type.name }}{% endfilter %}</span>
+                {% else %}
+                    <span class="mini quiet">{% trans 'Unknown content' %}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/backend/backend/templates/profile_csv_import.html
+++ b/backend/backend/templates/profile_csv_import.html
@@ -1,0 +1,19 @@
+{% extends 'admin/base.html' %}
+
+{% block content %}
+    <div>
+        <form action="." method="POST" enctype="multipart/form-data">
+
+            <p>If you have a set of users in a spreadsheet or csv file, you can import them in bulk.</p>
+
+            Download the <a href="{% url 'sample-csv-template' %}">sample csv file</a>, fill in the columns, then upload the file with the widget below.
+
+            {{ form.as_p }}
+            {% csrf_token %}
+
+            <button type="submit">Upload CSV</button>
+        </form>
+    </div>
+    <br />
+
+{% endblock %}

--- a/backend/backend/users/admin.py
+++ b/backend/backend/users/admin.py
@@ -7,6 +7,7 @@ from taggit.forms import TagField
 from taggit_labels.widgets import LabelWidget
 
 
+from .site_admin import constellation_admin
 from backend.users.forms import UserChangeForm, UserCreationForm
 from backend.users.models import Profile, Cluster
 
@@ -32,11 +33,13 @@ class UserAdmin(auth_admin.UserAdmin):
     search_fields = ["name"]
 
 
+@admin.register(Profile, site=constellation_admin)
 @admin.register(Profile)
 class ProfileAdmin(admin.ModelAdmin):
     form = ProfileAdminForm
 
 
 @admin.register(Cluster)
+@admin.register(Cluster, site=constellation_admin)
 class ClusterAdmin(admin.ModelAdmin):
     pass

--- a/backend/backend/users/importers.py
+++ b/backend/backend/users/importers.py
@@ -65,7 +65,8 @@ class ProfileImporter:
         self, profile: Profile, row: OrderedDict, columns: List = None
     ):
         """
-        Take a profile object, and add all the relevant tags, in the properties from the CSV listed `columns`.
+        Take a profile object, and add all the relevant tags,
+        in the properties from the CSV listed `columns`.
         """
         if not columns:
             columns = ["tags"]

--- a/backend/backend/users/importers.py
+++ b/backend/backend/users/importers.py
@@ -31,14 +31,18 @@ class ProfileImporter:
 
     rows = []
 
-    def load_csv(self, import_path: Path = None):
+    def load_csv_from_path(self, import_path: Path = None):
+        with open(import_path) as csvfile:
+            self.load_csv(csvfile)
+
+    def load_csv(self, csvfile=None):
         # Loads the rows contents of a CSV, returning an datastructure
         self.rows = []
-        with open(import_path) as csvfile:
-            reader = csv.DictReader(csvfile)
 
-            for row in reader:
-                self.rows.append(row)
+        reader = csv.DictReader(csvfile)
+
+        for row in reader:
+            self.rows.append(row)
 
     def create_users(self, rows=None):
         if not rows:

--- a/backend/backend/users/importers.py
+++ b/backend/backend/users/importers.py
@@ -1,9 +1,11 @@
 import csv
 from pathlib import Path
 import requests
+from datetime import datetime
 
 from backend.users.models import User, Profile
 from django.core.files.images import ImageFile
+from django.utils.text import slugify
 
 # How it works
 
@@ -15,6 +17,11 @@ from django.core.files.images import ImageFile
 import logging
 
 logger = logging.getLogger(__file__)
+logger.setLevel(logging.DEBUG)
+
+
+class NoEmailFound(Exception):
+    pass
 
 
 class ProfileImporter:
@@ -37,14 +44,19 @@ class ProfileImporter:
             rows = self.rows
 
         created_users = []
+        skipped_users = []
 
         for count, row in enumerate(rows):
 
             logger.debug(f"{count}, {row['name']}, rows to run through: {len(rows)}")
-            new_user = self.create_user(row)
-            created_users.append(new_user)
+            try:
+                new_user = self.create_user(row)
+                created_users.append(new_user)
+            except NoEmailFound:
+                skipped_users.append(row)
 
-        logger.debug("made it")
+        logger.debug(f"Added {len(created_users)}")
+        logger.debug(f"Skipped {len(created_users)}")
 
         return created_users
 
@@ -54,34 +66,41 @@ class ProfileImporter:
         on the info passed in
         """
         if not row["email"]:
+            raise (NoEmailFound)
             return None
 
         # create django user
-        user = User(name=row["name"], email=row["email"], username=row["name"])
+        safer_int = str(datetime.now().microsecond)[:4]
+        safer_name = f"{slugify(row['name'])}-{safer_int}"
+
+        user, created = User.objects.get_or_create(
+            name=row["name"], email=row["email"], username=safer_name
+        )
+
         logger.debug(user)
         user.save()
         logger.debug(user.id)
 
-        visible = (
-            row["visible"] == "visible"
-            or row["visible"] == "true"
-            or row["visible"] == "yes"
-        )
+        visible = True
 
-        profile = Profile(
+        tags = f"{row.get('tags')}"
+        profile, created = Profile.objects.get_or_create(
             user=user,
-            phone=row["phone"],
-            website=row["website"],
-            twitter=row["twitter"],
-            facebook=row["facebook"],
-            linkedin=row["linkedin"],
-            bio=row["blurb"],
+            phone=row.get("phone"),
+            website=row.get("website"),
+            twitter=row.get("twitter"),
+            facebook=row.get("facebook"),
+            linkedin=row.get("linkedin"),
+            bio=row.get("bio"),
             visible=visible,
-            photo=self.fetch_user_pic(row["photo"]),
+            photo=self.fetch_user_pic(row.get("photo")),
         )
 
         # create corresponding profile
+        for tag in tags.split(","):
+            profile.tags.add(tag)
         profile.save()
+
         logger.debug(f"profile: {profile}")
         logger.debug(f"user: {user}")
         logger.debug(profile.user.id)

--- a/backend/backend/users/management/commands/import_users.py
+++ b/backend/backend/users/management/commands/import_users.py
@@ -1,0 +1,30 @@
+import logging
+
+import django.contrib.auth
+from django.core.management import BaseCommand
+from backend.users.importers import ProfileImporter
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+console = logging.StreamHandler()
+console.setLevel(logging.DEBUG)
+logger.addHandler(console)
+logger.setLevel(logging.DEBUG)
+
+
+class Command(BaseCommand):
+    help = "Import user profiles into constallte "
+
+    def handle(self, *args, **kwargs):
+        importer = ProfileImporter()
+        csv_path = Path() / "cats.csv"
+
+        importer.load_csv(csv_path)
+        first_row = importer.rows[1]
+
+        logger.debug(f"importing: {first_row}")
+        users = importer.create_users(importer.rows)
+        logger.debug(f"imported: {users}")
+        # logger.debug(f"No of profiles to import: {len(importer.rows)}")
+        # logger.debug(f"No of profiles to import: {len(importer.rows)}")
+

--- a/backend/backend/users/site_admin.py
+++ b/backend/backend/users/site_admin.py
@@ -1,0 +1,75 @@
+from io import StringIO
+from django.contrib.admin.sites import AdminSite
+from django import forms
+from django.urls import path
+from django.shortcuts import render, redirect, reverse
+from django.contrib import messages
+
+from .importers import ProfileImporter
+
+
+class CsvImportForm(forms.Form):
+    csv_file = forms.FileField()
+
+
+class ConstellationAdmin(AdminSite):
+    # This is a standard authentication form that allows non-staff users
+    # login_form = AuthenticationForm
+    site_header = "Constellate Admin"
+    index_title = "Constellate Admin"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        patterns = [
+            path("import-csv/", self.import_csv, name="import-profiles"),
+        ]
+
+        return patterns + urls
+
+    def get_app_list(self, request):
+        app_list = super().get_app_list(request)
+        patterns = [
+            {
+                "name": "Import new profiles",
+                "app_label": "backend",
+                "app_url": "/admin/import-csv/",
+                "models": [
+                    {
+                        "name": "Profile Import",
+                        "object_name": "profile_import",
+                        "admin_url": "/admin/import-csv/",
+                        "view_only": True,
+                    }
+                ],
+            }
+        ]
+        return app_list + patterns
+
+    def import_csv(self, request):
+        from .admin import ProfileAdmin
+
+        if request.method == "POST":
+            csv_file = request.FILES["csv_file"]
+
+            # the uploaded file is bytestream,
+            # but we need a string
+            csv_text_file = StringIO(csv_file.read().decode("utf-8"))
+
+            importer = ProfileImporter()
+            importer.load_csv(csv_text_file)
+            created_users = importer.create_users()
+
+            messages.add_message(
+                request,
+                messages.INFO,
+                f"Your csv file with users has been imported. {len(created_users)} new profiles were imported.",
+            )
+
+            return redirect("/admin/users/profile/")
+
+        form = CsvImportForm()
+        payload = {"form": form}
+        return render(request, "profile_csv_import.html", payload)
+
+
+constellation_admin = ConstellationAdmin(name="constellation_admin")

--- a/backend/backend/users/tests/generated-sample-data.csv
+++ b/backend/backend/users/tests/generated-sample-data.csv
@@ -1,4 +1,4 @@
-name,admin,visible,tags,photo,email,phone,website,twitter,linkedin,facebook,blurb
+name,admin,visible,tags,photo,email,phone,website,twitter,linkedin,facebook,bio
 Walton Little,false,true,"government, policy",,Dean95@hotmail.com,,,,,,
 Cristobal Sipes,false,true,"creative, design",,Lucinda.Jakubowski@gmail.com,,philpottdesign.com,,,,
 Ms. Toby Carter,false,true,"entrepreneur, Non-exec director",,Dawson_Rolfson@yahoo.com,,,,,,

--- a/backend/backend/users/tests/test_importers.py
+++ b/backend/backend/users/tests/test_importers.py
@@ -33,7 +33,7 @@ class TestImporter:
         Load a CSV into memory, so we can manipulate it easily.
         """
         importer = ProfileImporter()
-        importer.load_csv(csv_path)
+        importer.load_csv_from_path(csv_path)
         assert len(importer.rows) > 0
         assert len(importer.rows) < 400
 
@@ -42,7 +42,7 @@ class TestImporter:
         Create a user with the provided email address
         """
         importer = ProfileImporter()
-        importer.load_csv(csv_path)
+        importer.load_csv_from_path(csv_path)
         assert User.objects.count() == 0
         importer.create_users()
 
@@ -51,7 +51,7 @@ class TestImporter:
     def test_create_user(self, csv_path):
 
         importer = ProfileImporter()
-        importer.load_csv(csv_path)
+        importer.load_csv_from_path(csv_path)
 
         user = importer.create_user(importer.rows[0])
 

--- a/backend/backend/users/tests/test_importers.py
+++ b/backend/backend/users/tests/test_importers.py
@@ -1,7 +1,4 @@
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from django.http.response import Http404
-from django.test import RequestFactory
 
 from collections import OrderedDict
 

--- a/backend/backend/users/tests/test_importers.py
+++ b/backend/backend/users/tests/test_importers.py
@@ -3,11 +3,13 @@ from django.contrib.auth.models import AnonymousUser
 from django.http.response import Http404
 from django.test import RequestFactory
 
-from backend.users.models import User
-from backend.users.tests.factories import UserFactory
-from backend.users.importers import ProfileImporter
+from collections import OrderedDict
 
 from pathlib import Path
+
+
+from backend.users.importers import ProfileImporter, User
+
 pytestmark = pytest.mark.django_db
 
 
@@ -15,9 +17,11 @@ pytestmark = pytest.mark.django_db
 def generated_users():
     pass
 
+
 @pytest.fixture
 def csv_path():
     return Path(__file__).parent / "generated-sample-data.csv"
+
 
 class TestImporter:
 
@@ -26,6 +30,7 @@ class TestImporter:
 
 
     """
+
     def test_load_csv(self, csv_path):
         """
         Load a CSV into memory, so we can manipulate it easily.
@@ -54,3 +59,47 @@ class TestImporter:
         user = importer.create_user(importer.rows[0])
 
         assert User.objects.first() == user
+
+    @pytest.mark.parametrize(
+        "tag_string, tag_list,col_names",
+        (
+            ("tag1, tag2, tag3", ["tag1", "tag2", "tag3"], ["tags"]),
+            ("tag1, tag2, tag3", ["tag1", "tag2", "tag3"], []),
+        ),
+    )
+    def test_add_tags_to_user(self, profile, tag_string, tag_list, col_names):
+
+        # arrange
+        importer = ProfileImporter()
+        row = OrderedDict()
+        row["tags"] = tag_string
+
+        # act
+        tagged_profile = importer.add_tags_to_profile(profile, row, col_names)
+
+        # assert
+        for tag in tag_list:
+            assert tag in tagged_profile.tags.names()
+
+    def test_add_multiple_kinds_of_tags_to_user(self, profile):
+
+        # arrange
+        first_tag_string = "tag1, tag2, tag3"
+        second_tag_string = "tag4, tag5, tag6"
+        importer = ProfileImporter()
+        row = OrderedDict()
+        row["tags"] = first_tag_string
+        row["some_other_name"] = second_tag_string
+
+        # act
+        tagged_profile = importer.add_tags_to_profile(
+            profile, row, ["tags", "some_other_name"]
+        )
+
+        # assert
+        for tag in first_tag_string.split(","):
+            assert tag.strip() in tagged_profile.tags.names()
+
+        for tag in second_tag_string.split(","):
+            assert tag.strip() in tagged_profile.tags.names()
+

--- a/backend/backend/users/views.py
+++ b/backend/backend/users/views.py
@@ -4,6 +4,9 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, RedirectView, UpdateView
+import csv
+from django.http import HttpResponse
+
 
 User = get_user_model()
 
@@ -48,3 +51,30 @@ class UserRedirectView(LoginRequiredMixin, RedirectView):
 
 
 user_redirect_view = UserRedirectView.as_view()
+
+
+def sample_csv_template(request):
+    # Create the HttpResponse object with the appropriate CSV header.
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="sample.csv"'
+
+    sampleProfile = {
+        "name": "Example name",
+        "admin": False,
+        "visible": False,
+        "tags": "comma, separated tags, here in quotes",
+        "photo": "https://link.website.com/profile-photo.jpg",
+        "email": "email@example.com",
+        "phone": "07974 123 456",
+        "website": "https://example.com",
+        "twitter": "https://twitter.com/username",
+        "linkedin": "https://linkedin.com/username",
+        "facebook": "https://facebook.com/username",
+        "bio": "A paragraph of text. Will be rendered as markdown and can contain links.",
+    }
+
+    writer = csv.writer(response)
+    writer.writerow(sampleProfile.keys())
+    writer.writerow(sampleProfile.values())
+
+    return response

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -6,6 +6,7 @@ from django.views import defaults as default_views
 from django.views.generic import TemplateView
 from rest_framework.authtoken.views import obtain_auth_token
 from django.contrib.flatpages.views import flatpage
+from backend.users.admin import constellation_admin as cl8_admin
 
 urlpatterns = [
     # serve the vue template instead of the default home
@@ -13,7 +14,8 @@ urlpatterns = [
 
 
     # Django Admin, use {% url 'admin:index' %}
-    path("admin/", admin.site.urls),
+    path("admin/", cl8_admin.urls),
+    path("advanced-admin/", admin.site.urls),
     # User management
     path("users/", include("backend.users.urls", namespace="users")),
     path("accounts/", include("allauth.urls")),

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,6 +7,7 @@ from django.views.generic import TemplateView
 from rest_framework.authtoken.views import obtain_auth_token
 from django.contrib.flatpages.views import flatpage
 from backend.users.admin import constellation_admin as cl8_admin
+from backend.users.views import sample_csv_template
 
 urlpatterns = [
     # serve the vue template instead of the default home
@@ -16,6 +17,9 @@ urlpatterns = [
     # Django Admin, use {% url 'admin:index' %}
     path("admin/", cl8_admin.urls),
     path("advanced-admin/", admin.site.urls),
+    path(
+        "admin/import-csv/sample.csv", sample_csv_template, name="sample-csv-template"
+    ),
     # User management
     path("users/", include("backend.users.urls", namespace="users")),
     path("accounts/", include("allauth.urls")),


### PR DESCRIPTION
This PR introduces a CSV import feature in the backend, staff facing, django admin.

The user facing view looks a bit like this:

<img width="1155" alt="Screenshot 2020-10-09 at 11 54 17" src="https://user-images.githubusercontent.com/17906/95569720-3a6a1d80-0a26-11eb-8153-a42a400c121d.png">

If you're a staff member, as long as you make a CSV file fit the columns in the provided sample csv, it can bulk import users. who will appear in the profile listing, and if they're marked as visible, appear in the front end too.

<img width="862" alt="Screenshot 2020-10-09 at 11 51 22" src="https://user-images.githubusercontent.com/17906/95569374-caf42e00-0a25-11eb-9430-d49182cebd3b.png">

The specific changes include:

- Adding the new import screen
- Adding the CSV importers, in the UI and on the command line
- Updates to the django admin - buy default `/admin/` is fairly pared back, but the full admin view is still visible at `/advanced-admin/` with the full set of editable pages, tokens, and the rest.

<img width="1146" alt="Screenshot 2020-10-09 at 11 58 05" src="https://user-images.githubusercontent.com/17906/95570098-b8c6bf80-0a26-11eb-933f-feb0bcba23b5.png">
