### PR TITLE
Use smaller portrait pic on detail pages

### DIFF
--- a/backend/backend/users/api/serializers.py
+++ b/backend/backend/users/api/serializers.py
@@ -1,17 +1,18 @@
 from django.contrib.auth import get_user_model
+from django.utils.text import slugify
 from rest_framework import serializers
+
+from taggit.models import Tag
 from taggit_serializer.serializers import (
-    TagListSerializerField,
     TaggitSerializer,
     TagList,
+    TagListSerializerField,
 )
-from taggit.models import Tag
-
-from rest_framework.utils import model_meta
 
 User = get_user_model()
-from ..models import Profile, Cluster
-from django.utils.text import slugify
+
+
+from ..models import Cluster, Profile
 
 
 class ConstellateTagListSerializerField(TagListSerializerField):
@@ -140,12 +141,9 @@ class ProfileSerializer(TaggitSerializer, serializers.ModelSerializer):
             "clusters",
             "photo",
             "thumbnail_photo",
+            "detail_photo",
         ]
-        read_only_fields = [
-            "photo",
-            "id",
-            "thumbnail_photo",
-        ]
+        read_only_fields = ["photo", "id", "thumbnail_photo", "detail_photo"]
 
 
 class TagSerializer(TaggitSerializer, serializers.ModelSerializer):

--- a/backend/backend/users/models.py
+++ b/backend/backend/users/models.py
@@ -76,6 +76,18 @@ class Profile(models.Model):
 
         return get_thumbnail(self.photo, "100x100", crop="center", quality=99).url
 
+    @property
+    def detail_photo(self):
+        """
+        A photo, designed for showing on a page, when viewing a profile, with
+        a user's details
+
+        """
+        if not self.photo:
+            return None
+
+        return get_thumbnail(self.photo, "250x250", crop="center", quality=99).url
+
     def __str__(self):
         return self.user.name
 

--- a/backend/backend/users/tests/test_drf_views.py
+++ b/backend/backend/users/tests/test_drf_views.py
@@ -17,13 +17,19 @@ pytestmark = pytest.mark.django_db
 
 
 class TestProfileViewSet:
-    def test_get_queryset(self, profile: Profile, rf: RequestFactory):
+    @pytest.mark.parametrize("visible,profile_count", [(True, 1), (False, 0),])
+    def test_get_queryset(
+        self, profile: Profile, rf: RequestFactory, visible, profile_count
+    ):
+
+        profile.visible = visible
+        profile.save()
         view = ProfileViewSet()
         request = rf.get("/fake-url/")
         request.user = profile.user
         view.request = request
 
-        assert profile in view.get_queryset()
+        assert len(view.get_queryset()) is profile_count
 
     def test_me(self, profile_with_tags: Profile, rf: RequestFactory):
         view = ProfileViewSet()

--- a/backend/backend/users/tests/test_models.py
+++ b/backend/backend/users/tests/test_models.py
@@ -33,9 +33,13 @@ class TestProfile:
 
         assert profile.admin is True
 
-    def test_profile_photo_thumbs(self, fake_photo_profile: Profile, settings):
+    @pytest.mark.only
+    @pytest.mark.parametrize("photo_size", [("thumbnail_photo"), ("detail_photo")])
+    def test_profile_photo_thumbs(
+        self, fake_photo_profile: Profile, settings, photo_size
+    ):
 
-        pic_url = fake_photo_profile.thumbnail_photo
+        pic_url = getattr(fake_photo_profile, photo_size,)
 
         # is this pointing to the correct directory where our media is stored?
         assert settings.MEDIA_URL in pic_url

--- a/backend/backend/users/tests/test_serializer.py
+++ b/backend/backend/users/tests/test_serializer.py
@@ -1,5 +1,5 @@
 import pytest
-from django.test import RequestFactory
+
 
 from backend.users.api.views import ProfileViewSet
 from backend.users.models import User, Profile
@@ -11,10 +11,11 @@ pytestmark = pytest.mark.django_db
 
 class TestProfileSerializer:
     @pytest.mark.only
-    def test_profile_with_photo(self, fake_photo_profile: Profile):
+    @pytest.mark.parametrize("photo_size", [("thumbnail_photo"), ("detail_photo")])
+    def test_profile_with_photo(self, fake_photo_profile: Profile, photo_size):
 
         ps = ProfileSerializer(fake_photo_profile)
-        assert "thumbnail_photo" in ps.data.keys()
+        assert photo_size in ps.data.keys()
 
     # @pytest.mark.only
     def test_create_profile_data(self):
@@ -23,7 +24,8 @@ class TestProfileSerializer:
         # user.save()
 
         profile_dict = {
-            # these are the bits we need to create for end users, before putting them back in the returned
+            # these are the bits we need to create for end users,
+            # before putting them back in the returned
             "name": "Joe Bloggs",
             "email": "person@email.com",
             "phone": "9329275526",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,14 +23,13 @@ export default {
     const currentUser = await fetchCurrentUser(this.$store)
 
     if (!currentUser) {
-      this.$router.push({name: 'signin'})
+      if (this.$router.currentRoute.name !== 'signin') {
+        this.$router.push({ name: 'signin' })
+      }
     }
   }
-
-
 }
 </script>
 
 <style>
-
 </style>

--- a/frontend/src/components/auth/Login.vue
+++ b/frontend/src/components/auth/Login.vue
@@ -16,7 +16,7 @@
               can pick it up and read out the announcement
             -->
             <div v-if="errors" class="errors">
-              <p v-for="(key) in errors.all()" v-bind:key="key">{{ key }}</p>
+              <p v-for="key in errors.all()" v-bind:key="key">{{ key }}</p>
             </div>
           </div>
 
@@ -26,26 +26,33 @@
             aria-live="polite"
             class="flex items-center justify-center pa3 bg-lightest-blue navy f6"
           >
-            <svg class="w1" data-icon="info" viewBox="0 0 32 32" style="fill:currentcolor">
+            <svg
+              class="w1"
+              data-icon="info"
+              viewBox="0 0 32 32"
+              style="fill: currentcolor"
+            >
               <title>info icon</title>
               <path
                 d="M16 0 A16 16 0 0 1 16 32 A16 16 0 0 1 16 0 M19 15 L13 15 L13 26 L19 26 z M16 6 A3 3 0 0 0 16 12 A3 3 0 0 0 16 6"
               />
             </svg>
-            <span class="ml3">{{signInData.message}}</span>
+            <span class="ml3">{{ signInData.message }}</span>
           </div>
 
           <form v-on:submit.prevent class="w-100 pa3 dib border-box mw6 ph5">
-              <p class="gray measure tl lh-copy">
-                {{ $t('message.login.instructions') }}
-              </p>
+            <p class="gray measure tl lh-copy">
+              {{ $t('message.login.instructions') }}
+            </p>
             <div class="w-100 mb3">
               <input
                 type="text"
                 name="email"
                 v-model="email"
                 class="input-reset br2 pa2 ba b--light-gray mt1 w-100"
-                :class=" {'bg-washed-red b--red': errors ? errors.has('email') : null}"
+                :class="{
+                  'bg-washed-red b--red': errors ? errors.has('email') : null
+                }"
                 :placeholder="$t('message.login.form.placeholder')"
                 :aria-label="$t('message.login.form.placeholder')"
                 autocomplete="email"
@@ -54,7 +61,9 @@
               />
 
               <div>
-                <small v-if="errors && errors.has('email')" class="red">{{ errors.first('email') }}</small>
+                <small v-if="errors && errors.has('email')" class="red">{{
+                  errors.first('email')
+                }}</small>
               </div>
             </div>
 
@@ -68,15 +77,15 @@
                   name="login-code"
                   v-model="token"
                   class="input-reset pa2 ba br2 b--light-gray w-100"
-                  :class=" {'bg-washed-red b--red': errors && errors.has('token') }"
+                  :class="{
+                    'bg-washed-red b--red': errors && errors.has('token')
+                  }"
                   :placeholder="$t('message.login.emailSubmitted.loginCode')"
                   :aria-label="$t('message.login.emailSubmitted.loginCode')"
                 />
 
                 <div>
-                  <small
-                    v-if="errors && errors.has('token')"
-                    class="red">
+                  <small v-if="errors && errors.has('token')" class="red">
                     {{ errors.first('token') }}
                   </small>
                 </div>
@@ -84,30 +93,37 @@
               <div class="mt2 cf">
                 <button
                   class="f6 link br3 bn pv2 mb2 mt2 bg-light-silver b white w-60 ml0 mr1 fl"
-                  :class="{'bg-green pointer grow hover-bg-dark-green': formValid}"
+                  :class="{
+                    'bg-green pointer grow hover-bg-dark-green': formValid
+                  }"
                   :disabled="!formValid"
                   name="sign-in"
-                  @click="signIn">
+                  @click="signIn"
+                >
                   {{ $t('message.login.emailSubmitted.signinButton') }}
                 </button>
                 <button
                   class="f6 link br3 bn pv2 mb2 mt2 bg-light-silver b white w-60 ml0 mr1 fl bg-red pointer grow hover-bg-dark-red"
                   name="button"
-                  @click="resetForm">
+                  @click="resetForm"
+                >
                   {{ $t('message.login.emailSubmitted.resetButton') }}
-                  </button>
+                </button>
               </div>
             </div>
             <div v-else>
               <div class="mt2 cf">
                 <button
                   class="f6 link br3 bn pv2 mb2 mt2 bg-light-silver b white w-60 ml0 mr1 fl"
-                  :class="{'bg-green pointer grow hover-bg-dark-green': formValid}"
+                  :class="{
+                    'bg-green pointer grow hover-bg-dark-green': formValid
+                  }"
                   :disabled="!formValid"
                   name="button"
-                  @click="submitEmail">
+                  @click="submitEmail"
+                >
                   {{ $t('message.login.form.requestLoginCodeButton') }}
-                  </button>
+                </button>
               </div>
             </div>
           </form>
@@ -117,12 +133,11 @@
               <em>
                 {{ $t('message.login.helpInstructions.question') }}
                 <a class="f6 tc gray" :href="supportEmail">
-                  {{ $t('message.login.helpInstructions.suggestion') }}
-                  </a>.
-                </em>
+                  {{ $t('message.login.helpInstructions.suggestion') }} </a
+                >.
+              </em>
             </p>
           </footer>
-
         </div>
       </div>
     </div>
@@ -136,7 +151,7 @@ const debug = debugLib('cl8.Login')
 export default {
   name: 'Login',
   components: {},
-  data: function() {
+  data: function () {
     return {
       email: '',
       token: null,
@@ -147,14 +162,14 @@ export default {
     }
   },
   methods: {
-    checkForValidFormSubmission: function() {
+    checkForValidFormSubmission: function () {
       let validation = {
         email: this.email
       }
 
       return this.$validator
         .validateAll(validation)
-        .then(result => {
+        .then((result) => {
           if (!result) {
             this.formIsValid = result
             return false
@@ -162,26 +177,29 @@ export default {
           this.formIsValid = result
           return result
         })
-        .catch(err => {
+        .catch((err) => {
           debug(err)
         })
     },
-    resetForm: function() {
+    resetForm: function () {
       this.email = null
       this.emailSubmitted = false
     },
-    signIn: function() {
+    signIn: function () {
       let user = {
         email: this.email,
         token: this.token
       }
       this.$store.dispatch('login', user)
     },
-    submitEmail: async function() {
-      const emailSubmitted = await this.$store.dispatch(
-        'submitEmail',
-        this.email
-      )
+    submitEmail: async function () {
+      let emailSubmitted
+      try {
+        emailSubmitted = await this.$store.dispatch('submitEmail', this.email)
+      } catch (e) {
+        debug({ e })
+        // bubble up the error so we see it in the login
+      }
 
       if (emailSubmitted) {
         this.emailSubmitted = true
@@ -189,13 +207,13 @@ export default {
     }
   },
   computed: {
-    formValid: function() {
+    formValid: function () {
       return this.formIsValid
     },
-    signInData: function() {
+    signInData: function () {
       return this.$store.getters.signInData
     },
-    loading: function() {
+    loading: function () {
       return this.$store.getters.isLoading
     }
   }

--- a/frontend/src/components/profile/ProfileDetail.vue
+++ b/frontend/src/components/profile/ProfileDetail.vue
@@ -276,7 +276,7 @@ export default {
     },
     hasPhoto,
     showPhoto() {
-      return this.profile.photo
+      return this.profile.detail_photo
     },
     async resendInvite() {
       debug('resendInvite', this.profile)

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -36,13 +36,13 @@ function checkForToken(token, context, router) {
 
 
 const getters = {
-  currentUser: function(state) {
+  currentUser: function (state) {
     return state.user
   },
-  isLoading: function(state) {
+  isLoading: function (state) {
     return state.loading
   },
-  isAdmin: function(state) {
+  isAdmin: function (state) {
     if (state.user == null) return false
     if (state.profileList == null) return false
 
@@ -53,24 +53,24 @@ const getters = {
       .map(profile => profile.id)
       .includes(state.user.id)
   },
-  currentTerm: function(state) {
+  currentTerm: function (state) {
     return state.searchTerm
   },
-  activeTags: function(state) {
+  activeTags: function (state) {
     debug('activeTags', state.searchTags)
     return state.searchTags
-},
+  },
   activeClusters: function (state) {
     debug('activeClusters', state.searchClusters)
     return state.searchClusters
   },
-  profile: function(state) {
+  profile: function (state) {
     return state.profile
   },
-  profilePhoto: function(state) {
+  profilePhoto: function (state) {
     return state.profilePhoto
   },
-  profileList: function(state) {
+  profileList: function (state) {
     debug('getting profileList')
     return state.profileList
   },
@@ -93,19 +93,19 @@ const getters = {
   profileShowing: function (state) {
     return state.profileShowing
   },
-  requestUrl: function(state) {
+  requestUrl: function (state) {
     return state.requestUrl
   },
-  signInData: function(state) {
+  signInData: function (state) {
     return state.signInData
   },
-  token: function(state) {
+  token: function (state) {
     return state.token
   }
 }
 
 const mutations = {
-  CLEAR_USER: function(state) {
+  CLEAR_USER: function (state) {
     state.profile = null
     state.user = null
     state.token = null
@@ -114,13 +114,13 @@ const mutations = {
     debug('state', state);
 
   },
-  stopLoading: function(state) {
+  stopLoading: function (state) {
     state.loading = false
   },
-  startLoading: function(state) {
+  startLoading: function (state) {
     state.loading = true
   },
-  setTerm: function(state, payload) {
+  setTerm: function (state, payload) {
     debug('setTerm', payload)
     debug('setTerm', typeof payload)
     state.searchTerm = payload
@@ -138,9 +138,9 @@ const mutations = {
     state.token = payload
     localStorage.token = payload
   },
-  SET_PROFILE: function(state, payload) {
+  SET_PROFILE: function (state, payload) {
     debug('SET_PROFILE', payload)
-    debug('PROFILE TAGS', payload.tags.map(x => {return x.name}))
+    debug('PROFILE TAGS', payload.tags.map(x => { return x.name }))
     state.profileShowing = true
     state.profile = payload
   },
@@ -164,7 +164,7 @@ const mutations = {
     debug('setProfilePhoto', payload)
     state.profile.photo = [payload]
   },
-  SET_VISIBLE_PROFILE_LIST: function(state, payload) {
+  SET_VISIBLE_PROFILE_LIST: function (state, payload) {
     debug('SET_VISIBLE_PROFILE_LIST', payload)
     state.profileList = payload
   },
@@ -176,11 +176,11 @@ const mutations = {
     debug('profileShowing', state.profileShowing)
     state.profileShowing = !state.profileShowing
   },
-  setRequestUrl: function(state, payload) {
+  setRequestUrl: function (state, payload) {
     debug('setrequestUrl', payload)
     state.requestUrl = payload
   },
-  SET_USER: function(state, payload) {
+  SET_USER: function (state, payload) {
     debug('SET_USER', payload)
     state.user = payload
   }
@@ -188,7 +188,7 @@ const mutations = {
 
 const actions = {
   // otherwise log user in here
-  submitEmail: async function(context, payload) {
+  submitEmail: async function (context, payload) {
     debug('action:submitEmail')
     const emailPayload = {
       email: payload
@@ -204,12 +204,12 @@ const actions = {
         return false
       }
 
-    }catch(error) {
-      return error
+    } catch (error) {
+      throw error
     }
 
   },
-  login: async function(context, payload) {
+  login: async function (context, payload) {
     try {
       const response = await instance.post('/auth/token/', payload)
       const token = response.data.token
@@ -230,7 +230,7 @@ const actions = {
       debug('Error logging in', error)
     }
   },
-  logout: function(context) {
+  logout: function (context) {
     context.commit('CLEAR_USER')
     router.push('signin')
   },
@@ -316,9 +316,9 @@ const actions = {
       debug('Error fetching tagList', error)
     }
   },
-  addUser: async function(context, payload) {
+  addUser: async function (context, payload) {
     debug('action:fetchProfile')
-    payload.tags = payload.tags.map(function(obj) {
+    payload.tags = payload.tags.map(function (obj) {
       return obj.name
     })
 
@@ -352,7 +352,7 @@ const actions = {
     })
     context.commit('SET_PROFILE', profile.data)
   },
-  resendInvite: async function(context, payload) {
+  resendInvite: async function (context, payload) {
     debug('action:resendInvite')
     const token = context.getters.token
     const profileId = payload.id
@@ -367,7 +367,7 @@ const actions = {
     )
     return response
   },
-  updateProfile: async function(context, payload) {
+  updateProfile: async function (context, payload) {
     debug('sending update to API', payload)
 
     // doing this round trip returns a JSON object we
@@ -403,7 +403,7 @@ const actions = {
       return 'There was a problem saving changes to the profile.'
     }
   },
-  updateProfilePhoto: async function(context, payload) {
+  updateProfilePhoto: async function (context, payload) {
     debug('action:updateProfilePhoto')
     const profileId = payload.profile.id
     const token = context.getters.token
@@ -432,7 +432,7 @@ const actions = {
     }
   },
 
-  newProfileTag: async function(context, payload) {
+  newProfileTag: async function (context, payload) {
     debug('action:newProfileTag', payload)
     const newTag = payload
     let tempVal =
@@ -443,9 +443,9 @@ const actions = {
       id: 'tempval' + tempVal
     }
     let profile = context.getters.profile
-    let tags = profile.tags 
+    let tags = profile.tags
     tags.push(tag)
-  
+
     context.commit('SET_PROFILE_TAGS', tags)
   },
 }

--- a/frontend/tests/unit/specs/__snapshots__/LoginComponent.spec.js.snap
+++ b/frontend/tests/unit/specs/__snapshots__/LoginComponent.spec.js.snap
@@ -39,9 +39,8 @@ exports[`Login.Vue mounting with expected data shows login form when loaded 1`] 
           <p class="f6 tc gray"><em>
 
               <a href="mailto:support@domain.com" class="f6 tc gray">
-                
-                </a>.
-              </em></p>
+                 </a>.
+            </em></p>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
Previously, while we had nice small thumbnails in the sidebar listings, sometimes if we had very large image uploaded by users for the profile, we'd show this huge file, rather than an appropriately sized profile pic.

This now makes sure we serve an appropriately sized profile photo on the detail view of a profile too.