### PR TITLE
Fix CSV import

### DIFF
--- a/cl8/users/management/commands/import_users.py
+++ b/cl8/users/management/commands/import_users.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.core.management import BaseCommand
-from cl8.users.importers import ProfileImporter
+from cl8.users.importers import CSVImporter
 
 logger = logging.getLogger(__name__)
 console = logging.StreamHandler()
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         parser.add_argument("csv_path", type=str)
 
     def handle(self, *args, **options):
-        importer = ProfileImporter()
+        importer = CSVImporter()
 
         csv_path = options.get("csv_path")
 


### PR DESCRIPTION
It looks like `ProfileImporter` was renamed to `CSVImporter` in f8a4cd3feef46bf1fe5a8adac70afe417a91ec1a, but this import was not updated. This commit should fix that.